### PR TITLE
Tree "underscore function" dependency removal

### DIFF
--- a/omero_autotag/views.py
+++ b/omero_autotag/views.py
@@ -15,6 +15,7 @@ import omero
 from omero.rtypes import rstring, unwrap
 from omeroweb.webclient import tree
 from .utils import create_tag_annotations_links
+from omero.constants.metadata import NSINSIGHTTAGSET
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +101,7 @@ def create_tag(request, conn=None, **kwargs):
 
     e["set"] = (
         e["ns"]
-        and tree.unwrap_to_str(e["ns"]) == omero.constants.metadata.NSINSIGHTTAGSET
+        and tree.unwrap_to_str(e["ns"]) == NSINSIGHTTAGSET
     )
 
     return JsonResponse(e)


### PR DESCRIPTION
This PR gets rid of dependencies on "underscore functions" from `omeroweb.webclient.tree`.

The dependencies are effectively not an issue with the fix introduced in https://github.com/ome/omero-web/pull/577, but removing them simplifies the code here as most of it was anyway duplicates of code from `marshal_images` and `marshal_tags` with results formatted to fit inputs of `_marshal_image` and `_marshal_tag`. The plugin needs its marshal functions to get the image clientPath.

