### PR TITLE
Token filter

### DIFF
--- a/omero_autotag/views.py
+++ b/omero_autotag/views.py
@@ -15,6 +15,7 @@ import omero
 from omero.rtypes import rstring, unwrap
 from omeroweb.webclient import tree
 from .utils import create_tag_annotations_links
+from omero.constants.metadata import NSINSIGHTTAGSET
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +101,7 @@ def create_tag(request, conn=None, **kwargs):
 
     e["set"] = (
         e["ns"]
-        and tree.unwrap_to_str(e["ns"]) == omero.constants.metadata.NSINSIGHTTAGSET
+        and tree.unwrap_to_str(e["ns"]) == NSINSIGHTTAGSET
     )
 
     return JsonResponse(e)

--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -65,19 +65,8 @@ export default class AutoTagForm extends React.Component {
       return false;
     }
 
-    // Reject tokens that are just numbers and/or symbols
-    if ( /^([0-9-\;\.\(\)]+)$/.test(tokenValue) ) {
-      return false;
-    }
-
-    // Accept any combination of letters, numbers and symbols
-    if ( /^([\s\-_A-Za-z0-9-\;\.\(\)]+)$/.test(tokenValue) ) {
-      return true;
-    }
-
-    // Reject anything else
-    return false;
-
+    // Accept anything else
+    return true;
   }
 
   addOrUpdateToken(image, tagValuesMap, tokenMap, value) {


### PR DESCRIPTION
Fixes #10

There previously was a filter on tokens extracted from the original path. I removed it almost completely (only empty tokens are rejected).

There should already be some filtering ahead with characters allowed to have in a file name. I assume that the user has a reason for using special characters in the file name, so no need to reject them as tags in OMERO.