### PR TITLE
Tokens additionally from image name

### DIFF
--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -107,21 +107,21 @@ export default class AutoTagForm extends React.Component {
     const escapedString = this.state.separators.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
     const regexPattern = RegExp(`[${escapedString}]+`);
 
+
+    const allTokens = new Set();
+    // Split and add tokens from image.clientPath
+    image.clientPath.split(regexPattern).forEach(value => allTokens.add(value));
+    // Split and add tokens from image.name
+    image.name.split(regexPattern).forEach(value => allTokens.add(value));
+
+    // Process each unique token
     let imageTokens = new Set();
-
-    let tokens = image.clientPath.split(regexPattern);
-    tokens.forEach(value =>
-      imageTokens.add(this.addOrUpdateToken(tagValuesMap, tokenMap, value))
-    );
-
-    tokens = image.name.split(regexPattern); // Splitting on brackets too
-    tokens.forEach(value =>
+    allTokens.forEach(value =>
       imageTokens.add(this.addOrUpdateToken(tagValuesMap, tokenMap, value))
     );
 
     // Return the set of tokens that are present on this image
     return imageTokens;
-
   }
 
   loadFromServer(imageIds) {
@@ -258,7 +258,6 @@ export default class AutoTagForm extends React.Component {
     images.forEach(image => {
       // Find the tokens on each image, updating the tokenMap in place
       image.tokens = this.tokensInName(image, tagValuesMap, tokenMap);
-      console.log(image.tokens);
 
       // Check any tokens that exist on this image by default
       image.checkedTokens = new Set(image.tokens);
@@ -694,11 +693,11 @@ export default class AutoTagForm extends React.Component {
     // Filter out any tokens that do not meet the requirements
     // Requirements for inclusion:
     // 1) Matches an existing tag value
-    // 2) Is present on required number of images AND Is not numbers and/or symbols only
+    // 2) Is present on required number of images
     let tokenMap = new Map([...this.state.tokenMap].filter(kv => {
       let token = kv[1];
-
       return (
+
         token.possible.size > 0 ||
         (
           token.count >= this.state.requiredTokenCardinality &&

--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -62,17 +62,11 @@ export default class AutoTagForm extends React.Component {
   }
 
   tokenValueCheck (tokenValue) {
-
     // Reject empty tokens
-    if (tokenValue.length === 0) {
-      return false;
-    }
-
-    // Accept anything else
-    return true;
+    return tokenValue.length > 0
   }
 
-  addOrUpdateToken(image, tagValuesMap, tokenMap, value) {
+  addOrUpdateToken(tagValuesMap, tokenMap, value) {
 
     let token;
 
@@ -117,12 +111,12 @@ export default class AutoTagForm extends React.Component {
 
     let tokens = image.clientPath.split(regexPattern);
     tokens.forEach(value =>
-      imageTokens.add(this.addOrUpdateToken(image, tagValuesMap, tokenMap, value))
+      imageTokens.add(this.addOrUpdateToken(tagValuesMap, tokenMap, value))
     );
 
     tokens = image.name.split(regexPattern); // Splitting on brackets too
     tokens.forEach(value =>
-      imageTokens.add(this.addOrUpdateToken(image, tagValuesMap, tokenMap, value))
+      imageTokens.add(this.addOrUpdateToken(tagValuesMap, tokenMap, value))
     );
 
     // Return the set of tokens that are present on this image

--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -27,7 +27,9 @@ export default class AutoTagForm extends React.Component {
       unmappedTags: new Set(),
       showUnmapped: false,
       requiredTokenCardinality: 2,
-      maxTokenCardinality: 2
+      maxTokenCardinality: 2,
+      separators: " _./\\[]",
+      tagValuesMap: new Map()
     }
 
     // Abort capable AJAX variables
@@ -43,6 +45,7 @@ export default class AutoTagForm extends React.Component {
     this.refreshForm = this.refreshForm.bind(this);
     this.toggleUnmapped = this.toggleUnmapped.bind(this);
     this.handleChangeRequiredTokenCardinality = this.handleChangeRequiredTokenCardinality.bind(this);
+    this.handleChangeSeparator = this.handleChangeSeparator.bind(this);
 
   }
 
@@ -54,7 +57,7 @@ export default class AutoTagForm extends React.Component {
       tokenMap: new Map(),
       unmappedTags: new Set(),
       requiredTokenCardinality: 2,
-      maxTokenCardinality: 2
+      maxTokenCardinality: 2,
     });
   }
 
@@ -106,13 +109,18 @@ export default class AutoTagForm extends React.Component {
 
   tokensInName(image, tagValuesMap, tokenMap) {
 
+    // escape special characters
+    const escapedString = this.state.separators.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    const regexPattern = RegExp(`[${escapedString}]+`);
+
     let imageTokens = new Set();
 
-    let tokens = image.clientPath.split(/[\/\\_\.\s]+/);
+    let tokens = image.clientPath.split(regexPattern);
     tokens.forEach(value =>
       imageTokens.add(this.addOrUpdateToken(image, tagValuesMap, tokenMap, value))
     );
-    tokens = image.name.split(/[\/\\_\.\s\[\]]+/); // Splitting on brackets too
+
+    tokens = image.name.split(regexPattern); // Splitting on brackets too
     tokens.forEach(value =>
       imageTokens.add(this.addOrUpdateToken(image, tagValuesMap, tokenMap, value))
     );
@@ -194,30 +202,17 @@ export default class AutoTagForm extends React.Component {
 
         });
 
-        // Set of all tags which are used in at least one image, irrespective of
-        // whether there is a token mapping using it or possible using it
-        let allAppliedTags = new Set();
-
-        // The possible mapping of tokens to tags
-        // The active mapping
-        // Counts of token use
-        let tokenMap = new Map();
-
+        // Generate the image objects
         let images = new Set();
-
-        // Process the images
         jsonData.images.forEach(jsonImage => {
-
           // Resolve the owner ID to a user
           let imageOwner = users.get(jsonImage.ownerId);
-
           // Get the tags that correspond to these tagIds
           let imageTags = new Set(
             jsonImage.tags.map(
               jsonTagId => tags.get(jsonTagId)
             )
           );
-
           // Add the image to the set
           let image = new Image(
             jsonImage.id,
@@ -228,65 +223,12 @@ export default class AutoTagForm extends React.Component {
             imageTags
           );
           images.add(image);
-
-
-          // Find the tokens on each image, updating the tokenMap in place
-          image.tokens = this.tokensInName(image, tagValuesMap, tokenMap);
-
-          // Check any tokens that exist on this image by default
-          image.checkedTokens = new Set(image.tokens);
-
-          // Add any tags found on this image to this definitive set of used
-          // tags
-          allAppliedTags = union(allAppliedTags, image.tags);
-
         });
 
-        // Process the images again now that the token->tag map is complete as
-        // the image may have tags applied for token->tag mappings where it
-        // does not have the token. These should also be marked as checked
-        // automatically
-
-        // Get the reverse mapping of the tags to tokens. This is only possible
-        // because there should be a 1:1 mapping between tokens and tags
-        let activeTagTokenMap = new Map([...tokenMap].filter(
-          kv => kv[1].isActive()
-        ).map(
-          kv => [kv[1].activeTag, kv[1]]
-        ));
-
-        // Also get the activeTagTokenMap as a Set for set operations
-        let activeTagSet = new Set(activeTagTokenMap.keys());
-
-        // Find the tags which are mapped in some way
-        let mappedTags = new Set();
-        tokenMap.forEach(token => {
-          mappedTags = union(mappedTags, token.possible);
-        });
-
-        // Find the tags that are not applied in any way
-        let unmappedTags = difference(allAppliedTags, mappedTags);
-
-
-        // Check tokens due to applied tags for auto-mappings and
-        // Check tags due to applied tags where there are no mappings
-        images.forEach(image => {
-
-          // Get the set of tags on this image that are currently mapped
-          let appliedImageTags = intersection(activeTagSet, image.tags);
-
-          // Lookup the tokens which those tags are mapped to and mark them
-          // as checked
-          appliedImageTags.forEach(tag => {
-            let token = activeTagTokenMap.get(tag);
-            image.checkToken(token);
-          });
-
-          // Get the set of tags that are on the image, but not involved in
-          // any mapping. Apply this to checkedTags
-          image.checkedTags = intersection(image.tags, unmappedTags);
-
-        });
+        const res = this.initialize_image_tokens(images, tagValuesMap);
+        images = res[0];
+        let tokenMap = res[1];
+        let unmappedTags = res[2];;
 
         // Set the state
         // Special case requiredTokenCardinality for when there is only one image
@@ -297,16 +239,86 @@ export default class AutoTagForm extends React.Component {
           tokenMap: tokenMap,
           unmappedTags: unmappedTags,
           requiredTokenCardinality: images.size === 1 ? 1 : 2,
-          maxTokenCardinality: images.size
+          maxTokenCardinality: images.size,
+          tagValuesMap: tagValuesMap
         });
 
       }
     );
+  }
 
-    //   error: function(xhr, status, err) {
-    //     console.error(this.props.url, status, err.toString());
-    //   }.bind(this)
-    // });
+  initialize_image_tokens(images, tagValuesMap) {
+    // Separate initialize token function to refresh the tokens
+    // each time separators are changed, without sending query to the server
+
+    // Set of all tags which are used in at least one image, irrespective of
+    // whether there is a token mapping using it or possible using it
+    let allAppliedTags = new Set();
+
+    // The possible mapping of tokens to tags
+    // The active mapping
+    // Counts of token use
+    let tokenMap = new Map();
+
+    // Process the images
+    images.forEach(image => {
+      // Find the tokens on each image, updating the tokenMap in place
+      image.tokens = this.tokensInName(image, tagValuesMap, tokenMap);
+      console.log(image.tokens);
+
+      // Check any tokens that exist on this image by default
+      image.checkedTokens = new Set(image.tokens);
+
+      // Add any tags found on this image to this definitive set of used tags
+      allAppliedTags = union(allAppliedTags, image.tags);
+    });
+
+    // Process the images again now that the token->tag map is complete as
+    // the image may have tags applied for token->tag mappings where it
+    // does not have the token. These should also be marked as checked
+    // automatically
+
+    // Get the reverse mapping of the tags to tokens. This is only possible
+    // because there should be a 1:1 mapping between tokens and tags
+    let activeTagTokenMap = new Map([...tokenMap].filter(
+      kv => kv[1].isActive()
+    ).map(
+      kv => [kv[1].activeTag, kv[1]]
+    ));
+
+    // Also get the activeTagTokenMap as a Set for set operations
+    let activeTagSet = new Set(activeTagTokenMap.keys());
+
+    // Find the tags which are mapped in some way
+    let mappedTags = new Set();
+    tokenMap.forEach(token => {
+      mappedTags = union(mappedTags, token.possible);
+    });
+
+    // Find the tags that are not applied in any way
+    let unmappedTags = difference(allAppliedTags, mappedTags);
+
+
+    // Check tokens due to applied tags for auto-mappings and
+    // Check tags due to applied tags where there are no mappings
+    images.forEach(image => {
+
+      // Get the set of tags on this image that are currently mapped
+      let appliedImageTags = intersection(activeTagSet, image.tags);
+
+      // Lookup the tokens which those tags are mapped to and mark them
+      // as checked
+      appliedImageTags.forEach(tag => {
+        let token = activeTagTokenMap.get(tag);
+        image.checkToken(token);
+      });
+
+      // Get the set of tags that are on the image, but not involved in
+      // any mapping. Apply this to checkedTags
+      image.checkedTags = intersection(image.tags, unmappedTags);
+
+    });
+    return [images, tokenMap, unmappedTags];
   }
 
   componentDidMount() {
@@ -660,6 +672,30 @@ export default class AutoTagForm extends React.Component {
     });
   }
 
+  handleChangeSeparator(value) {
+    // Do not use setState here yet (would already refresh the page)
+    this.state.separators = value;
+
+    let images = this.state.images;
+    let tagValuesMap = this.state.tagValuesMap;
+    tokenMap, unmappedTags;
+
+    // Recompute the image tokens
+    const res = this.initialize_image_tokens(images, tagValuesMap);
+    images = res[0];
+    let tokenMap = res[1];
+    let unmappedTags = res[2];
+
+    // Set the state
+    // Special case requiredTokenCardinality for when there is only one image
+    this.setState({
+      images: images,
+      tokenMap: tokenMap,
+      unmappedTags: unmappedTags
+    });
+
+  }
+
   filteredTokenMap() {
     // Filter out any tokens that do not meet the requirements
     // Requirements for inclusion:
@@ -690,6 +726,8 @@ export default class AutoTagForm extends React.Component {
                         handleChangeRequiredTokenCardinality={this.handleChangeRequiredTokenCardinality}
                         toggleUnmapped={this.toggleUnmapped}
                         refreshForm={this.refreshForm}
+                        separators={this.state.separators}
+                        handleChangeSeparator={this.handleChangeSeparator}
         />
 
         <AutoTagTable tokenMap={this.filteredTokenMap()}

--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -112,6 +112,10 @@ export default class AutoTagForm extends React.Component {
     tokens.forEach(value =>
       imageTokens.add(this.addOrUpdateToken(image, tagValuesMap, tokenMap, value))
     );
+    tokens = image.name.split(/[\/\\_\.\s\[\]]+/); // Splitting on brackets too
+    tokens.forEach(value =>
+      imageTokens.add(this.addOrUpdateToken(image, tagValuesMap, tokenMap, value))
+    );
 
     // Return the set of tokens that are present on this image
     return imageTokens;

--- a/src/AutoTagHeaderRow.jsx
+++ b/src/AutoTagHeaderRow.jsx
@@ -37,7 +37,7 @@ export default class AutoTagHeaderRow extends React.Component {
         <tr>
           {cellNodesToken}
           {cellNodesTag}
-          <th>Original Import Path</th>
+          <th>Original Import Path<br/>Image Name</th>
         </tr>
       </thead>
     );

--- a/src/AutoTagHeaderRowTokenCell.jsx
+++ b/src/AutoTagHeaderRowTokenCell.jsx
@@ -93,7 +93,7 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
 
     return (
       <th>
-        <div className={'token'}>{token.value}
+        <div className={'token'}>{token.value}<br/>
           <input type="checkbox"
                  checked={this.isChecked()}
                  disabled={this.isDisabled()}

--- a/src/AutoTagImageRow.jsx
+++ b/src/AutoTagImageRow.jsx
@@ -43,7 +43,7 @@ export default class AutoTagImageRow extends React.Component {
       <tr>
         {cellNodesToken}
         {cellNodesTag}
-        <td style={{whiteSpace: 'nowrap'}}>{image.clientPath}&nbsp;({image.id})</td>
+        <td style={{whiteSpace: 'nowrap'}}>{image.clientPath}<br/>{image.name}&nbsp;(id:{image.id})</td>
       </tr>
     );
   }

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -93,10 +93,12 @@ export default class AutoTagToolbar extends React.Component {
         </ReactTooltip>
 
         <input type="text"
-               size="10"
+               size="5"
                onChange={this.handleChangeSeparator}
                value={this.props.separators}
-               />
+               style={{
+                marginRight: '20px'
+              }} />
 
         <span
           data-tip
@@ -112,7 +114,10 @@ export default class AutoTagToolbar extends React.Component {
 
         <input type="checkbox"
                checked={this.props.showUnmapped}
-               onChange={this.toggleUnmapped} />
+               onChange={this.toggleUnmapped}
+               style={{
+                marginRight: '20px'
+              }} />
 
         <input type="submit"
                id="applyButton"

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -11,6 +11,7 @@ export default class AutoTagToolbar extends React.Component {
     this.refreshForm = this.refreshForm.bind(this);
     this.toggleUnmapped = this.toggleUnmapped.bind(this);
     this.handleChangeRequiredTokenCardinality = this.handleChangeRequiredTokenCardinality.bind(this);
+    this.handleChangeSeparator = this.handleChangeSeparator.bind(this);
 
   }
 
@@ -25,6 +26,10 @@ export default class AutoTagToolbar extends React.Component {
 
   handleChangeRequiredTokenCardinality(e) {
     this.props.handleChangeRequiredTokenCardinality(e.target.value);
+  }
+
+  handleChangeSeparator(e) {
+    this.props.handleChangeSeparator(e.target.value);
   }
 
   render() {
@@ -74,6 +79,24 @@ export default class AutoTagToolbar extends React.Component {
         <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" type="dark" effect="float">
           Hide columns if token is found on fewer than this number of images
         </ReactTooltip>
+
+        <span
+          data-tip
+          data-for={'tooltip-toolbar-show-all'}
+          style={{fontSize: '12px', fontWeight: 'bold', lineHeight: '29px'}}
+        >
+          Split on&nbsp;
+        </span>
+
+        <ReactTooltip id={'tooltip-toolbar-show-all'} place="bottom" type="dark" effect="float">
+          Characters used to split the path and names to find relevant tags.
+        </ReactTooltip>
+
+        <input type="text"
+               size="10"
+               onChange={this.handleChangeSeparator}
+               value={this.props.separators}
+               />
 
         <span
           data-tip


### PR DESCRIPTION
Fixes #2 :
The image name can be different than the name of the file imported found in the "original import path" (the client path). Thus this also includes the image name in the possible tokens.

Fixes #7 :
The name includes the series's label (the part in the bracket at the end of an image name)