### PR TITLE
Use the release/v1 branch for the PyPA action publishing to PyPI

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -22,6 +22,6 @@ jobs:
           python setup.py sdist bdist_wheel
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.3.0
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
See https://github.com/ome/omero-py/pull/456