### PR TITLE
Handle multi page results from tree.marshal_tags

### DIFF
--- a/omero_autotag/views.py
+++ b/omero_autotag/views.py
@@ -10,6 +10,8 @@ from django.http import (
     HttpResponseBadRequest,
     JsonResponse,
 )
+from django.conf import settings
+
 from omeroweb.webclient.decorators import login_required
 import omero
 from omero.rtypes import rstring, unwrap
@@ -126,7 +128,14 @@ def get_image_detail_and_tags(request, conn=None, **kwargs):
         group_id = conn.getEventContext().groupId
 
     # All the tags available to the user
-    tags = tree.marshal_tags(conn, group_id=group_id)
+    tags = []
+    page = 0
+    while True:
+        next_tags = tree.marshal_tags(conn, group_id=group_id, page=page)
+        tags.extend(next_tags)
+        if len(next_tags) < settings.PAGE:
+            break
+        page += 1
 
     # Details about the images specified
     params = omero.sys.ParametersI()

--- a/omero_autotag/views.py
+++ b/omero_autotag/views.py
@@ -129,7 +129,7 @@ def get_image_detail_and_tags(request, conn=None, **kwargs):
 
     # All the tags available to the user
     tags = []
-    page = 0
+    page = 1
     while True:
         next_tags = tree.marshal_tags(conn, group_id=group_id, page=page)
         tags.extend(next_tags)


### PR DESCRIPTION
Fixes #19 

In this fix, all pages of tags are loaded from `tree.marshal`

Loading less tags would mean there would not be the option to apply any existing tag to the images list.
Also it would need to keep the tags based on the filename splits and would have to reload each time the splitting is changed