### PR TITLE
Image Ids shortened in the View source 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ local_settings.py
 *.egg-info
 dist
 build
+node_modules
+var/
+omero_autotag/static/
+package-lock.json

--- a/omero_autotag/views.py
+++ b/omero_autotag/views.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from builtins import map, str
 from collections import defaultdict
 from copy import deepcopy
 import json

--- a/omero_autotag/views.py
+++ b/omero_autotag/views.py
@@ -113,15 +113,22 @@ def create_tag(request, conn=None, **kwargs):
 def get_image_detail_and_tags(request, conn=None, **kwargs):
     # According to REST, this should be a GET, but because of the amount of
     # data being submitted, this is problematic
-    if not request.POST:
+    if request.method != "POST":
         return HttpResponseNotAllowed("Methods allowed: POST")
 
-    image_ids = request.POST.getlist("imageIds[]")
+    try:
+        data = json.loads(request.body or b"{}")
+    except json.JSONDecodeError:
+        return HttpResponseBadRequest("Invalid request format")
 
-    if not image_ids:
+    image_ids = data.get("imageIds")
+    if not isinstance(image_ids, list) or not image_ids:
         return HttpResponseBadRequest("Image IDs required")
 
-    image_ids = list(map(int, image_ids))
+    try:
+        image_ids = [int(x) for x in image_ids]
+    except (TypeError, ValueError):
+        return HttpResponseBadRequest("Invalid imageIds; must be integers")
 
     group_id = request.session.get("active_group")
     if group_id is None:

--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -138,11 +138,14 @@ export default class AutoTagForm extends React.Component {
       return;
     }
 
+    const ids = Array.isArray(imageIds) ? imageIds : Array.from(imageIds || []);
+
     this.loadRequest = $.ajax({
       url: this.props.url,
       type: "POST",
-      data: { imageIds: imageIds },
-      dataType: 'json',
+      contentType: "application/json",
+      dataType: "json",
+      data: JSON.stringify({ imageIds: ids }), // JSON array
       cache: false
     });
 


### PR DESCRIPTION
Tries to fix #21 

The encoded image Ids in the Network - Payload - View source are simplified. The image shows modified view.

<img width="648" height="350" alt="NetworkPayloadViewSrc" src="https://github.com/user-attachments/assets/7b35021f-dd22-447d-9939-6dcb1701b961" />
 