### PR TITLE
Replace react-select with custom JS because CSS

### DIFF
--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -366,7 +366,14 @@
 }
 
 #auto_tag_panel .tag_button {
-	display:inline-block;
+	display:inline-flex;
+	align-items:center;
+	justify-content:center;
+	vertical-align:middle;
+	padding-left: 7px;
+  padding-right: 5px;
+  padding-top: 1px;
+  padding-bottom: 1px;
     -webkit-border-radius: 30px;
 	-moz-border-radius: 30px;
 	border-radius: 30px;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
         test: /\.css$/,
         use: ['style-loader', 'css-loader']
       },
-      { 
+      {
         test: /\.png$/,
         type: 'asset',
         parser: {


### PR DESCRIPTION
Bumping the react and react-select version caused changes in the CSS selector. Quite hard to disantangle what was going on in the code and in the CSS. 

Found this workaround that get rid of the react Select so I could apply styles easier.