### PR TITLE
Script version in html to bust cache on script update

### DIFF
--- a/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
+++ b/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
@@ -1,4 +1,5 @@
-<script src="{% static "omero_autotag/js/bundle.min.js" %}"></script>
+<!-- Update version below to match package.json version for cache busting -->
+<script src="{% static "omero_autotag/js/bundle.min.js" %}?v=4.2.2"></script>
 
 <script>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtagging-autotag",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "",
   "main": "bundle.js",
   "scripts": {


### PR DESCRIPTION
Add a version to the script import in the HTML so that upon update of the plugin, the clients will be forced to refresh their cached script.

Right now would need to be handled upon version bump. Need to add documentation for later publication.