### PR TITLE
React v5 support and CSS corrections

### DIFF
--- a/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
+++ b/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
@@ -1,5 +1,5 @@
 <!-- Update version below to match package.json version for cache busting -->
-<script src="{% static "omero_autotag/js/bundle.min.js" %}?v=4.2.2"></script>
+<script src="{% static "omero_autotag/js/bundle.min.js" %}?v=4.2.3"></script>
 
 <script>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtagging-autotag",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "",
   "main": "bundle.js",
   "scripts": {

--- a/src/AutoTagHeaderRowTokenCell.jsx
+++ b/src/AutoTagHeaderRowTokenCell.jsx
@@ -93,7 +93,7 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
                  disabled={this.isDisabled()}
                  onChange={this.handleCheckedChangeAll} />
         </div>
-        <div className={'tag'} >
+        <div className={'tag'} data-tooltip-id={this.getTooltipId()}>
           <Select
             name="tokenmapselect"
             onChange={this.selectMapping}
@@ -113,7 +113,6 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
             styles={{
               option: (provided, state) => ({
                 ...provided,
-                // Check if this is the "New / Existing Tag" option
                 color: state.data.value.id === '__new__' ? 'blue' : provided.color,
                 fontWeight: state.data.value.id === '__new__' ? 'bold' : provided.fontWeight,
                 borderStyle: state.data.value.id === '__new__' ? 'solid' : provided.borderStyle,
@@ -122,7 +121,12 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
           />
           {
             this.props.tag &&
-            <ReactTooltip id={this.getTooltipId()} place="top" variant="dark" className={"autotag_tooltip"}>
+            <ReactTooltip
+              id={this.getTooltipId()}
+              place="top"
+              variant="dark"
+              className={"autotag_tooltip"}
+            >
               <ul>
                 <li><strong>ID:</strong> {this.props.tag.id}</li>
                 <li><strong>Value:</strong> {this.props.tag.value}</li>

--- a/src/AutoTagHeaderRowTokenCell.jsx
+++ b/src/AutoTagHeaderRowTokenCell.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Tooltip as ReactTooltip } from 'react-tooltip';
-// lightweight custom dropdown used instead of react-select
+import Select from 'react-select';
 
 export default class AutoTagHeaderRowTokenCell extends React.Component {
 
@@ -12,9 +12,6 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
     this.selectMapping = this.selectMapping.bind(this);
     this.formatTagLabel = this.formatTagLabel.bind(this);
     this.selectGetOptionLabel = this.selectGetOptionLabel.bind(this);
-    this.toggleMenu = this.toggleMenu.bind(this);
-    this.handleDocumentClick = this.handleDocumentClick.bind(this);
-    this.handleOptionSelect = this.handleOptionSelect.bind(this);
 
     this.state = {
       menuOpen: false
@@ -56,46 +53,13 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
     }
   }
 
-  componentDidMount() {
-    document.addEventListener('click', this.handleDocumentClick);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('click', this.handleDocumentClick);
-  }
-
-  toggleMenu(e) {
-    e.stopPropagation();
-    this.setState({menuOpen: !this.state.menuOpen});
-  }
-
-  handleDocumentClick() {
-    if (this.state.menuOpen) {
-      this.setState({menuOpen: false});
-    }
-  }
-
-  handleOptionSelect(tag) {
-    // tag === undefined means New/Existing
-    if (tag === undefined) {
-      this.props.newMapping(this.props.token);
-    } else {
-      this.props.selectMapping(this.props.token, tag);
-    }
-    this.setState({menuOpen: false});
-  }
-
   getTooltipId() {
     return 'tooltip-token-' + this.props.token.value;
   }
 
   selectGetOptionLabel(option) {
-    let label = this.formatTagLabel(option);
-
-    return (
-      <span data-tooltip-id={this.getTooltipId()}>{label}</span>
-    )
-	}
+    return this.formatTagLabel(option.value);
+  }
 
   render() {
     let token = this.props.token;
@@ -118,7 +82,7 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
 
     options.push({
       value: undefined,
-      label: newExisting
+      label: "New/Existing Tag"
     });
 
     let tagClassName = "tag_button";
@@ -135,30 +99,19 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
                  onChange={this.handleCheckedChangeAll} />
         </div>
         <div className={'tag'} >
-          <div className={'tag_dropdown'} style={{position: 'relative', display: 'inline-block'}}>
-            <span className={tagClassName} onClick={this.toggleMenu} data-tooltip-id={tag ? this.getTooltipId() : undefined}>
-              { tag ? ("" + tag.value + "\u00a0(" + tag.id + ")") : '\u00a0' }
-              <span style={{marginLeft:3}}>▾</span>
-            </span>
-            { this.state.menuOpen &&
-              <div className={'tag_dropdown_menu'} style={{position:'absolute', top:'100%', left:0, zIndex:1000, background:'#fff', border:'1px solid #ccc', padding:'4px'}}>
-                {
-                  options.map((opt, idx) => {
-                    const optVal = opt.value; // possibleTag or undefined
-                    const label = (optVal !== undefined) ? (optVal.value + "\u00a0(" + optVal.id + ")") : null;
-                    return (
-                      <div key={idx}
-                           onClick={(e)=>{ e.stopPropagation(); this.handleOptionSelect(optVal); }}
-                           style={{padding:'4px 8px', cursor:'pointer', whiteSpace:'nowrap'}}
-                           data-tooltip-id={optVal ? this.getTooltipId() : undefined}>
-                        { optVal ? label : opt.label }
-                      </div>
-                    );
-                  })
-                }
-              </div>
-            }
-          </div>
+          <Select
+            name="tokenmapselect"
+            onChange={this.selectMapping}
+            options={options}
+            value={options.find(o => o.value?.id === tag?.id)}
+            getOptionLabel={(option) => this.formatTagLabel(option.value)}
+            getOptionValue={(option) => String(option.value?.id)}
+            isSearchable={false}
+            isClearable={true}
+            className={tagClassName}
+            placeholder=" "
+            classNamePrefix="react-select"
+          />
           {
             this.props.tag &&
             <ReactTooltip id={this.getTooltipId()} place="top" variant="dark" className={"autotag_tooltip"}>

--- a/src/AutoTagHeaderRowTokenCell.jsx
+++ b/src/AutoTagHeaderRowTokenCell.jsx
@@ -11,7 +11,6 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
     this.handleCheckedChangeAll = this.handleCheckedChangeAll.bind(this);
     this.selectMapping = this.selectMapping.bind(this);
     this.formatTagLabel = this.formatTagLabel.bind(this);
-    this.selectGetOptionLabel = this.selectGetOptionLabel.bind(this);
 
     this.state = {
       menuOpen: false
@@ -44,21 +43,21 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
   }
 
   selectMapping(option) {
-    if (option === null) {
-      this.props.selectMapping(this.props.token, null);
-    } else if (option.value !== undefined) {
-      this.props.selectMapping(this.props.token, option.value);
-    } else {
-      this.props.newMapping(this.props.token)
-    }
+  if (!option) {
+    this.props.selectMapping(this.props.token, null);
+    return;
   }
+
+  if (option.value.id === '__new__') {
+    this.props.newMapping(this.props.token);
+    return;
+  }
+
+  this.props.selectMapping(this.props.token, option.value);
+}
 
   getTooltipId() {
     return 'tooltip-token-' + this.props.token.value;
-  }
-
-  selectGetOptionLabel(option) {
-    return this.formatTagLabel(option.value);
   }
 
   render() {
@@ -76,12 +75,8 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
       }
     )
 
-    let newExisting = (
-      <span style={{color: "blue", fontWeight: "bold", borderStyle: "solid"}}>New/Existing Tag</span>
-    );
-
     options.push({
-      value: undefined,
+      value: { id: '__new__' },
       label: "New/Existing Tag"
     });
 
@@ -104,13 +99,26 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
             onChange={this.selectMapping}
             options={options}
             value={options.find(o => o.value?.id === tag?.id)}
-            getOptionLabel={(option) => this.formatTagLabel(option.value)}
-            getOptionValue={(option) => String(option.value?.id)}
+            getOptionLabel={(option) =>
+              option.value.id === '__new__'
+                ? 'New / Existing Tag'
+                : this.formatTagLabel(option.value)
+            }
+            getOptionValue={(option) => option.value.id}
             isSearchable={false}
             isClearable={true}
             className={tagClassName}
             placeholder=" "
             classNamePrefix="react-select"
+            styles={{
+              option: (provided, state) => ({
+                ...provided,
+                // Check if this is the "New / Existing Tag" option
+                color: state.data.value.id === '__new__' ? 'blue' : provided.color,
+                fontWeight: state.data.value.id === '__new__' ? 'bold' : provided.fontWeight,
+                borderStyle: state.data.value.id === '__new__' ? 'solid' : provided.borderStyle,
+              })
+            }}
           />
           {
             this.props.tag &&

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -54,36 +54,32 @@ export default class AutoTagToolbar extends React.Component {
 
         {
           this.props.showUnmapped &&
-          <span
-            data-tooltip-id={'tooltip-toolbar-slider'}
-            style={{
-              float: 'left',
-              marginLeft: '20px',
-              fontSize: '12px',
-              fontWeight: 'bold',
-              lineHeight: '29px'
-            }}
-          >Rarity Threshold&nbsp;&nbsp;{this.props.requiredTokenCardinality}</span>
+          <div style={{display: 'flex', alignItems: 'center', float: 'left', marginLeft: '20px', marginRight: '20px', lineHeight: '29px'}}>
+            <span
+              data-tooltip-id={'tooltip-toolbar-slider'}
+              style={{
+                fontSize: '12px',
+                fontWeight: 'bold',
+                marginRight: '10px'
+              }}
+            >Rarity Threshold&nbsp;&nbsp;{this.props.requiredTokenCardinality}</span>
+            <input className='slider'
+                   type='range'
+                   onChange={this.handleChangeRequiredTokenCardinality}
+                   value={this.props.requiredTokenCardinality}
+                   min={1}
+                   max={this.props.maxTokenCardinality}
+                   style={{
+                     cursor: 'pointer'
+                   }} />
+          </div>
         }
         {
           this.props.showUnmapped &&
-          <input className='slider'
-                 type='range'
-                 onChange={this.handleChangeRequiredTokenCardinality}
-                 value={this.props.requiredTokenCardinality}
-                 min={1}
-                 max={this.props.maxTokenCardinality}
-                 style={{
-                   float: 'left',
-                   marginLeft: '10px',
-                   lineHeight: '29px',
-                   paddingTop: '5px'
-                 }} />
+          <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" variant="dark">
+            Hide columns if token is found on fewer than this number of items.
+          </ReactTooltip>
         }
-
-        <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" variant="dark">
-          Hide columns if token is found on fewer than this number of items.
-        </ReactTooltip>
 
         <span
           data-tooltip-id={'tooltip-toolbar-split-chars'}

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -45,12 +45,15 @@ export default class AutoTagToolbar extends React.Component {
         className={'toolbar'}
       >
         <span
-          data-tip
-          data-for={'tooltip-toolbar-show-all'}
+          data-tooltip-id={'tooltip-toolbar-obj-type'}
           style={{float: 'left', marginLeft: '10px', fontSize: '12px', fontWeight: 'bold', lineHeight: '29px'}}
         >
           Tagging {this.props.itemType}s
         </span>
+
+        <ReactTooltip id={'tooltip-toolbar-obj-type'} place="bottom" variant="dark" offset={5}>
+          The object type currently being tagged. Selecting a Project will tag Datasets, selecting a Dataset or an Image will tag Images.
+        </ReactTooltip>
 
         {
           this.props.showUnmapped &&
@@ -72,13 +75,13 @@ export default class AutoTagToolbar extends React.Component {
                    style={{
                      cursor: 'pointer'
                    }} />
+            {
+              this.props.showUnmapped &&
+              <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" variant="dark" offset={-4} style={{lineHeight: '1'}}>
+                Hide columns if token is found on fewer than this number of items.
+              </ReactTooltip>
+            }
           </div>
-        }
-        {
-          this.props.showUnmapped &&
-          <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" variant="dark">
-            Hide columns if token is found on fewer than this number of items.
-          </ReactTooltip>
         }
 
         <span
@@ -88,7 +91,7 @@ export default class AutoTagToolbar extends React.Component {
           Split on&nbsp;
         </span>
 
-        <ReactTooltip id={'tooltip-toolbar-split-chars'} place="bottom" variant="dark">
+        <ReactTooltip id={'tooltip-toolbar-split-chars'} place="bottom" variant="dark" offset={5}>
           Characters used to split the path and names to find relevant tags.
         </ReactTooltip>
 
@@ -107,7 +110,7 @@ export default class AutoTagToolbar extends React.Component {
           Show All Potential Tags
         </span>
 
-        <ReactTooltip id={'tooltip-toolbar-show-all'} place="bottom" variant="dark">
+        <ReactTooltip id={'tooltip-toolbar-show-all'} place="bottom" variant="dark" offset={5}>
           Show all the tokens found in the filenames that do not match an existing tag
         </ReactTooltip>
 

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -106,7 +106,7 @@ export default class AutoTagToolbar extends React.Component {
 
         <span
           data-tooltip-id={'tooltip-toolbar-show-all'}
-          style={{fontSize: '12px', fontWeight: 'bold', lineHeight: '29px'}}
+          style={{fontSize: '12px', fontWeight: 'bold', lineHeight: '29px', marginRight: '5px'}}
         >
           Show All Potential Tags
         </span>
@@ -119,7 +119,9 @@ export default class AutoTagToolbar extends React.Component {
                checked={this.props.showUnmapped}
                onChange={this.toggleUnmapped}
                style={{
-                marginRight: '20px'
+                verticalAlign: 'middle',
+                marginRight: '20px',
+                cursor: 'pointer'
               }} />
 
         <input type="submit"

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -57,7 +57,7 @@ export default class AutoTagToolbar extends React.Component {
             variant="dark"
             offset={5}
             className={'autotag_toolbar_tooltip'} >
-          The object type currently being tagged. Selecting a Project will tag Datasets, selecting a Dataset or an Image will tag Images.
+          The object type currently being tagged.
         </ReactTooltip>
 
         {

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -51,7 +51,12 @@ export default class AutoTagToolbar extends React.Component {
           Tagging {this.props.itemType}s
         </span>
 
-        <ReactTooltip id={'tooltip-toolbar-obj-type'} place="bottom" variant="dark" offset={5}>
+        <ReactTooltip
+            id={'tooltip-toolbar-obj-type'}
+            place="bottom"
+            variant="dark"
+            offset={5}
+            className={'autotag_toolbar_tooltip'} >
           The object type currently being tagged. Selecting a Project will tag Datasets, selecting a Dataset or an Image will tag Images.
         </ReactTooltip>
 
@@ -77,7 +82,12 @@ export default class AutoTagToolbar extends React.Component {
                    }} />
             {
               this.props.showUnmapped &&
-              <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" variant="dark" offset={-4} style={{lineHeight: '1'}}>
+              <ReactTooltip
+                  id={'tooltip-toolbar-slider'}
+                  place="bottom"
+                  variant="dark"
+                  offset={-4}
+                  className={'autotag_toolbar_tooltip'} >
                 Hide columns if token is found on fewer than this number of items.
               </ReactTooltip>
             }
@@ -91,7 +101,12 @@ export default class AutoTagToolbar extends React.Component {
           Split on&nbsp;
         </span>
 
-        <ReactTooltip id={'tooltip-toolbar-split-chars'} place="bottom" variant="dark" offset={5}>
+        <ReactTooltip
+            id={'tooltip-toolbar-split-chars'}
+            place="bottom"
+            variant="dark"
+            offset={5}
+            className={'autotag_toolbar_tooltip'} >
           Characters used to split the path and names to find relevant tags.
         </ReactTooltip>
 
@@ -110,7 +125,12 @@ export default class AutoTagToolbar extends React.Component {
           Show All Potential Tags
         </span>
 
-        <ReactTooltip id={'tooltip-toolbar-show-all'} place="bottom" variant="dark" offset={5}>
+        <ReactTooltip
+            id={'tooltip-toolbar-show-all'}
+            place="bottom"
+            variant="dark"
+            offset={5}
+            className={'autotag_toolbar_tooltip'} >
           Show all the tokens found in the filenames that do not match an existing tag
         </ReactTooltip>
 

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -292,7 +292,7 @@
 
 #auto_tag_panel .react-select__placeholder,
 #auto_tag_panel .react-select__single-value {
-  padding-left: 7px;
+  padding-left: 5px;
   padding-right: 5px;
   white-space: nowrap;
   position: inherit;
@@ -389,13 +389,20 @@
   vertical-align: middle;
   white-space: nowrap;
   padding-right: 0px;
-  padding-left: 0px;
   padding-bottom: 0px;
+}
+
+#auto_tag_panel .react-select__clear-indicator,
+#auto_tag_panel .react-select__dropdown-indicator,
+#auto_tag_panel .react-select__indicators {
+  padding-left: 0px;
 }
 
 #auto_tag_panel .react-select__dropdown-indicator svg {
   width: 10px;
   height: 10px;
+  color: hsl(205, 30%, 35%);
+  fill: currentColor;
 }
 
 #auto_tag_panel .react-select__clear-indicator svg {

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -430,7 +430,7 @@
 	background:linear-gradient(to top, hsl(205,65%,80%) 0%,hsl(205,70%,75%) 100%); /* W3C */
 
 	text-decoration:none;
-	text-shadow: 0 1px 0 rgba(255,255,255,.4);
+	/*text-shadow: 0 1px 0 rgba(255,255,255,.4);*/
 	color:hsl(205,30%,30%);
 }
 

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -512,10 +512,16 @@
 
 #auto_tag_panel .autotag_tooltip {
     text-align: left;
-    font-size: 11px;
+    font-size: 12px;
     padding-top: 8px;
     padding-bottom: 8px;
     padding-left: 6px;
     padding-right: 30px;
     z-index: 1000;
+}
+
+#auto_tag_panel .autotag_toolbar_tooltip {
+    font-size: 13px;
+    z-index: 1000;
+    line-height: 1;
 }

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -365,6 +365,14 @@
 #auto_tag_panel .react-select__control {
   display: inline !important;
   white-space: nowrap !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+#auto_tag_panel .react-select__control:focus,
+#auto_tag_panel .react-select__control:focus-within {
+  outline: none !important;
+  box-shadow: none !important;
 }
 
 #auto_tag_panel .react-select__value-container {

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -517,4 +517,5 @@
     padding-bottom: 8px;
     padding-left: 6px;
     padding-right: 30px;
+    z-index: 1000;
 }

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -1,15 +1,16 @@
 
 /* Correct some aggressive CSS rules from dusty.css */
-.Select-arrow-zone {
-    display:table-cell !important;
+#auto_tag_panel .react-select__dropdown-indicator {
+  display: table-cell !important;
 }
 
-.Select-clear-zone {
-    display:table-cell !important;
+#auto_tag_panel .react-select__clear-indicator {
+  display: table-cell !important;
 }
 
-.Select-placeholder, .Select-option {
-    font-size:14px;
+#auto_tag_panel .react-select__placeholder,
+#auto_tag_panel .react-select__option {
+  font-size: 14px;
 }
 
 #auto_tag_panel .toolbar {
@@ -73,6 +74,8 @@
 
 #auto_tag_panel .token {
     text-align:center;
+    display: inline-flex;
+    align-items: center;
 }
 
 #auto_tag_panel .tag {
@@ -287,93 +290,113 @@
   }
 }
 
-#auto_tag_panel .Select-placeholder,
-#auto_tag_panel .Select-value {
+#auto_tag_panel .react-select__placeholder,
+#auto_tag_panel .react-select__single-value {
   padding-left: 7px;
   padding-right: 5px;
   white-space: nowrap;
-  position:inherit;
+  position: inherit;
   display: table-cell;
 }
 
-#auto_tag_panel .Select-control {
-    line-height:inherit;
-    height: auto;
-    border: 1px solid transparent;
+#auto_tag_panel .react-select__control {
+  line-height: inherit;
+  height: auto;
+  border: 1px solid transparent;
+  background: none transparent;
 }
 
-#auto_tag_panel .Select-placeholder,
-#auto_tag_panel .Select-value,
-#auto_tag_panel .Select-clear-zone,
-#auto_tag_panel .Select-arrow-zone {
+#auto_tag_panel .react-select__placeholder,
+#auto_tag_panel .react-select__single-value,
+#auto_tag_panel .react-select__clear-indicator,
+#auto_tag_panel .react-select__dropdown-indicator {
   line-height: inherit;
   height: auto;
   cursor: pointer;
 }
 
-#auto_tag_panel .Select-value-label {
-    text-shadow: 0 1px 0 rgba(255,255,255,.8);
-    color:hsl(205,30%,35%);
+#auto_tag_panel .react-select__single-value {
+  text-shadow: 0 1px 0 rgba(255,255,255,.8);
+  color: hsl(205,30%,35%);
 }
 
-#auto_tag_panel .Select-input {
-    line-height: inherit;
-    height: auto;
-    padding-left: 0;
-    padding-right: 0;
+#auto_tag_panel .react-select__input-container {
+  line-height: inherit;
+  height: auto;
+  padding-left: 0;
+  padding-right: 0;
 }
 
-#auto_tag_panel .Select-clear-zone,
-#auto_tag_panel .Select-arrow-zone {
-    padding: 0px 2px 0px 2px;
+#auto_tag_panel .react-select__clear-indicator,
+#auto_tag_panel .react-select__dropdown-indicator {
+  padding: 0px 2px;
 }
 
-#auto_tag_panel .Select-arrow-zone {
-    padding-top: 2px;
-    padding-right: 7px;
+#auto_tag_panel .react-select__dropdown-indicator {
+  padding-top: 2px;
+  padding-right: 7px;
 }
 
-#auto_tag_panel .Select-clear-zone{
-    font-weight: bold;
-    padding-bottom: 2px;
-    padding-right: 4px;
+#auto_tag_panel .react-select__clear-indicator {
+  font-weight: bold;
+  padding-bottom: 2px;
+  padding-right: 4px;
+  font-size: 10px;
+  color: black;
 }
 
-#auto_tag_panel .Select-control {
-  background: none transparent;
+#auto_tag_panel .react-select__placeholder {
+  font-size: inherit;
+  color: inherit;
 }
 
-#auto_tag_panel .Select-placeholder {
-    font-size: inherit;
-    color: inherit;
+#auto_tag_panel .react-select__menu {
+  width: auto;
+  margin-top: 2px;
 }
 
-#auto_tag_panel .Select-clear {
-    font-size: 10px;
-    color: black;
+#auto_tag_panel .react-select__option {
+  width: auto;
+  font-size: 11px;
+  padding-top: 3px;
+  padding-bottom: 3px;
 }
 
-#auto_tag_panel .Select-menu-outer {
-    width: auto;
-    margin-top: 2px;
+#auto_tag_panel .react-select__control {
+  display: inline !important;
+  white-space: nowrap !important;
 }
 
-#auto_tag_panel .Select-option {
-    width: auto;
-    font-size: 11px;
-    padding-top: 3px;
-    padding-bottom: 3px;
+#auto_tag_panel .react-select__value-container {
+  display: table-row !important;
+  padding-right: 0px;
+  padding-left: 2px;
+}
+
+#auto_tag_panel .react-select__single-value,
+#auto_tag_panel .react-select__clear-indicator,
+#auto_tag_panel .react-select__dropdown-indicator,
+#auto_tag_panel .react-select__indicators {
+  display: inline-flex !important;
+  vertical-align: middle;
+  white-space: nowrap;
+  padding-right: 0px;
+  padding-left: 0px;
+  padding-bottom: 0px;
+}
+
+#auto_tag_panel .react-select__dropdown-indicator svg {
+  width: 10px;
+  height: 10px;
+}
+
+#auto_tag_panel .react-select__clear-indicator svg {
+  width: 10px;
+  height: 10px;
 }
 
 #auto_tag_panel .tag_button {
-	display:inline-flex;
-	align-items:center;
-	justify-content:center;
-	vertical-align:middle;
-	padding-left: 7px;
-  padding-right: 5px;
-  padding-top: 1px;
-  padding-bottom: 1px;
+  display:inline-block;
     -webkit-border-radius: 30px;
 	-moz-border-radius: 30px;
 	border-radius: 30px;


### PR DESCRIPTION
This reverts back to using the React-Select for the selection of tags, that needed large number of changes since React-Select changed from v1.0 to v5.7

I also took the liberty to correct CSS alignment issues in the toolbar, including:
* the slidebar Rarity Threshold
* Show All Potential Tags checkbox
* Tooltips alignements
* Tooltip fontsize
* Tooltip z-index

Fix #35 and Fix #34 