### PR TITLE
Multi-selection support for all main types

### DIFF
--- a/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
+++ b/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
@@ -1,5 +1,5 @@
 <!-- Update version below to match package.json version for cache busting -->
-<script src="{% static "omero_autotag/js/bundle.min.js" %}?v=4.2.2"></script>
+<script src="{% static "omero_autotag/js/bundle.min.js" %}?v=4.2.3"></script>
 
 <script>
 

--- a/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
+++ b/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
@@ -31,7 +31,7 @@ $(function() {
         var childNode = datatree.get_node(childId);
 
         // Skip non-supported children of a tag
-        if (selectedNode.type === "tag" && ($.inArray(childNode.type, ["image", "dataset", "project"]) < 0)) {
+        if (selectedNode.type === "tag" && ($.inArray(childNode.type, ["image", "dataset", "project", "screen", "plate"]) < 0)) {
           return;
         }
 
@@ -48,7 +48,7 @@ $(function() {
       });
     });
 
-    var availableTypes = ['Project', 'Dataset', 'Image'];
+    var availableTypes = ['Screen', 'Plate', 'Project', 'Dataset', 'Image'];
     // Filter availableTypes to only include types that exist in childrenObjects or selectedObjects
     var objectTypes = new Set([selectedObjects[0].type]);
     childrenObjects.forEach(function(obj) { objectTypes.add(obj.type); });
@@ -132,7 +132,7 @@ $(function() {
       }
       var dtype = selected[0]['id'].split('-')[0];
       if (selected.length > 0) {
-          return ($.inArray(dtype, ["image", "dataset", "project", "tag", "orphaned"]) > -1);
+          return ($.inArray(dtype, ["image", "dataset", "project", "screen", "plate", "tag", "orphaned"]) > -1);
       } else {
           return false;
       }

--- a/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
+++ b/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
@@ -9,19 +9,54 @@ $(function() {
   var urlUpdate="{% url 'autotag_process_update' %}";
   var urlCreateTag="{% url 'autotag_create_tag' %}";
 
-  var reactRender = function(datatree, itemType, selectedNode) {
-    var itemIds = [];
-    $.each(selectedNode.children, function(index, child) {
-      if (selectedNode.type === "tag") {
-        var childNode = datatree.get_node(child);
-        if (childNode.type !== "image") {
-          // Skip non-image children of a tag
+  var reactRender = function(datatree, selectedNodes, availableTypes, defaultType) {
+    // Collect selected objects with their IDs
+    var selectedObjects = [];
+    var nodes = Array.isArray(selectedNodes) ? selectedNodes : [selectedNodes];
+
+    nodes.forEach(function(node) {
+      selectedObjects.push({
+        id: node.data.obj.id,
+        type: node.type,
+        name: node.text
+      });
+    });
+
+    // Collect children objects
+    var childrenObjects = [];
+    var processedIds = new Set();
+
+    nodes.forEach(function(selectedNode) {
+      selectedNode.children.forEach(function(childId) {
+        var childNode = datatree.get_node(childId);
+
+        // Skip non-image children of a tag
+        if (selectedNode.type === "tag" && childNode.type !== "image") {
           return;
         }
-      }
-      itemIds.push(datatree.get_node(child).data.obj.id);
+
+        // Avoid duplicates
+        if (!processedIds.has(childNode.data.obj.id)) {
+          childrenObjects.push({
+            id: childNode.data.obj.id,
+            type: childNode.type,
+            name: childNode.text
+          });
+          processedIds.add(childNode.data.obj.id);
+        }
+      });
     });
-    autotagform.default(itemIds, itemType, url, urlUpdate, urlCreateTag); // calls autotagform in Main.jsx
+
+    // Call the autotagform with structured data
+    autotagform.default(
+      selectedObjects,
+      childrenObjects,
+      availableTypes,
+      defaultType,
+      url,
+      urlUpdate,
+      urlCreateTag
+    );
   };
 
   $("#auto_tag_panel").omeroweb_center_plugin({
@@ -33,50 +68,88 @@ $(function() {
       var datatree = $.jstree.reference('#dataTree');
       if (!datatree) return;
 
-      // We use the tree to access selected items, since we can traverse
-      // to check parents etc...
-      // Note: We do not use the parameters selected, dtype or oid as
-      // it is easier to use the tree directly as these do not refer to
-      // a jstree node
+      // Get all selected items from the tree
       var tree_selected = datatree.get_selected(true);
 
-      if (tree_selected === undefined) {
+      if (tree_selected === undefined || tree_selected.length === 0) {
         return;
       }
 
-      // TODO Handle multi-selection
-      var selected = tree_selected[0];
+      console.log("AutoTag selected:", tree_selected);
 
-      // If the selected item is an image, return that image and its siblings
-      if (selected.type === 'image') {
-        // Set selected to be the parent so that lastSelected can be compared
-        // to the container
-        selected = datatree.get_node(datatree.get_parent(selected));
-        reactRender(datatree, "image", selected);
+      // Determine available types and default type based on selection
+      var availableTypes = [];
+      var defaultType = null;
+      var hasImages = tree_selected.some(node => node.type === 'image');
+      var hasDatasets = tree_selected.some(node => node.type === 'dataset');
+      var hasProjects = tree_selected.some(node => node.type === 'project');
+      var hasOrphaned = tree_selected.some(node => node.type === 'orphaned');
+      var hasTags = tree_selected.some(node => node.type === 'tag');
+
+      // Determine available item types based on selection
+      if (hasProjects) {
+        // Project selection: can tag Projects or Datasets
+        availableTypes = ['Project', 'Dataset'];
+        defaultType = 'Dataset';
+      } else if (hasDatasets) {
+        // Dataset selection: can tag Datasets or Images
+        availableTypes = ['Dataset', 'Image'];
+        defaultType = 'Image';
+      } else if (hasImages) {
+        // Image selection: can tag selected Images
+        availableTypes = ['Image'];
+        defaultType = 'Image';
+      } else if (hasOrphaned) {
+        // Orphaned selection: can only tag Images
+        availableTypes = ['Image'];
+        defaultType = 'Image';
+      } else if (hasTags) {
+        // Tag selection: can tag Projects, Datasets, or Images
+        availableTypes = ['Project', 'Dataset', 'Image'];
+        defaultType = 'Image';
       }
 
-      // If the selected item is a Dataset, tag or orphaned return its children
-      else if (selected.type === 'dataset' || selected.type === 'orphaned' || selected.type === 'tag'){
-        // Make sure that the dataset is loaded
-        if (!datatree.is_loaded(selected)) {
-          datatree.load_node(selected, function(node, status){
-            reactRender(datatree, "image", datatree.get_node(node));
-          });
-        } else {
-          reactRender(datatree, "image", datatree.get_node(selected));
+      // Ensure all selected nodes are loaded
+      var nodesToLoad = [];
+      tree_selected.forEach(function(node) {
+        if (!datatree.is_loaded(node)) {
+          nodesToLoad.push(node);
         }
-      } else if (selected.type === 'project') {
-        // For a project, load the datasets underneath it
-        if (!datatree.is_loaded(selected)) {
-          datatree.load_node(selected, function(node, status){
-            reactRender(datatree, "dataset", datatree.get_node(node));
+      });
+
+      if (nodesToLoad.length === 0) {
+        // All nodes already loaded
+        reactRender(datatree, tree_selected, availableTypes, defaultType);
+      } else {
+        // Load all unloaded nodes, then render
+        var loadedCount = 0;
+        var totalToLoad = nodesToLoad.length;
+
+        var checkAllLoaded = function() {
+          if (loadedCount === totalToLoad) {
+            reactRender(datatree, tree_selected, availableTypes, defaultType);
+          }
+        };
+
+        nodesToLoad.forEach(function(node) {
+          datatree.load_node(node, function(loadedNode, status) {
+            loadedCount++;
+            checkAllLoaded();
           });
-        } else {
-          reactRender(datatree, "dataset", datatree.get_node(selected));
-        }
+        });
       }
     },
-    supported_obj_types: ['dataset', 'image', 'orphaned', 'tag', 'project'],
+    plugin_enabled: function(selected){
+      // Required for multi-selection support
+      // supported_obj_types only works for single selection
+      if (selected.length == 0) return false;
+      var dtype = selected[0]['id'].split('-')[0];
+      if (selected.length > 1) {
+          return ($.inArray(dtype, ["image", "dataset"]) > -1);
+      } else {
+          return ($.inArray(dtype, ["image", "dataset", "tag", "orphaned", "project"]) > -1);
+      }
+    }
   });
 });
 

--- a/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
+++ b/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
@@ -9,7 +9,7 @@ $(function() {
   var urlUpdate="{% url 'autotag_process_update' %}";
   var urlCreateTag="{% url 'autotag_create_tag' %}";
 
-  var reactRender = function(datatree, selectedNodes, availableTypes, defaultType) {
+  var reactRender = function(datatree, selectedNodes) {
     // Collect selected objects with their IDs
     var selectedObjects = [];
     var nodes = Array.isArray(selectedNodes) ? selectedNodes : [selectedNodes];
@@ -30,22 +30,38 @@ $(function() {
       selectedNode.children.forEach(function(childId) {
         var childNode = datatree.get_node(childId);
 
-        // Skip non-image children of a tag
-        if (selectedNode.type === "tag" && childNode.type !== "image") {
+        // Skip non-supported children of a tag
+        if (selectedNode.type === "tag" && ($.inArray(childNode.type, ["image", "dataset", "project"]) < 0)) {
           return;
         }
 
-        // Avoid duplicates
-        if (!processedIds.has(childNode.data.obj.id)) {
+        // Avoid duplicates based on id and type combination
+        var uniqueKey = childNode.data.obj.id + '-' + childNode.type;
+        if (!processedIds.has(uniqueKey)) {
           childrenObjects.push({
             id: childNode.data.obj.id,
             type: childNode.type,
             name: childNode.text
           });
-          processedIds.add(childNode.data.obj.id);
+          processedIds.add(uniqueKey);
         }
       });
     });
+
+    var availableTypes = ['Project', 'Dataset', 'Image'];
+    // Filter availableTypes to only include types that exist in childrenObjects or selectedObjects
+    var objectTypes = new Set([selectedObjects[0].type]);
+    childrenObjects.forEach(function(obj) { objectTypes.add(obj.type); });
+
+    availableTypes = availableTypes.filter(function(type) {
+      return objectTypes.has(type.toLowerCase());
+    });
+
+    if (availableTypes.length === 0) {
+      return;
+    }
+    // Last type as default, prioritizing Image > Dataset > Project
+    defaultType = availableTypes[availableTypes.length - 1]
 
     // Call the autotagform with structured data
     autotagform.default(
@@ -77,38 +93,6 @@ $(function() {
 
       console.log("AutoTag selected:", tree_selected);
 
-      // Determine available types and default type based on selection
-      var availableTypes = [];
-      var defaultType = null;
-      var hasImages = tree_selected.some(node => node.type === 'image');
-      var hasDatasets = tree_selected.some(node => node.type === 'dataset');
-      var hasProjects = tree_selected.some(node => node.type === 'project');
-      var hasOrphaned = tree_selected.some(node => node.type === 'orphaned');
-      var hasTags = tree_selected.some(node => node.type === 'tag');
-
-      // Determine available item types based on selection
-      if (hasProjects) {
-        // Project selection: can tag Projects or Datasets
-        availableTypes = ['Project', 'Dataset'];
-        defaultType = 'Dataset';
-      } else if (hasDatasets) {
-        // Dataset selection: can tag Datasets or Images
-        availableTypes = ['Dataset', 'Image'];
-        defaultType = 'Image';
-      } else if (hasImages) {
-        // Image selection: can tag selected Images
-        availableTypes = ['Image'];
-        defaultType = 'Image';
-      } else if (hasOrphaned) {
-        // Orphaned selection: can only tag Images
-        availableTypes = ['Image'];
-        defaultType = 'Image';
-      } else if (hasTags) {
-        // Tag selection: can tag Projects, Datasets, or Images
-        availableTypes = ['Project', 'Dataset', 'Image'];
-        defaultType = 'Image';
-      }
-
       // Ensure all selected nodes are loaded
       var nodesToLoad = [];
       tree_selected.forEach(function(node) {
@@ -119,7 +103,7 @@ $(function() {
 
       if (nodesToLoad.length === 0) {
         // All nodes already loaded
-        reactRender(datatree, tree_selected, availableTypes, defaultType);
+        reactRender(datatree, tree_selected);
       } else {
         // Load all unloaded nodes, then render
         var loadedCount = 0;
@@ -127,7 +111,7 @@ $(function() {
 
         var checkAllLoaded = function() {
           if (loadedCount === totalToLoad) {
-            reactRender(datatree, tree_selected, availableTypes, defaultType);
+            reactRender(datatree, tree_selected);
           }
         };
 
@@ -139,15 +123,18 @@ $(function() {
         });
       }
     },
+
     plugin_enabled: function(selected){
       // Required for multi-selection support
       // supported_obj_types only works for single selection
-      if (selected.length == 0) return false;
+      if (selected.length == 0) {
+        return false;
+      }
       var dtype = selected[0]['id'].split('-')[0];
-      if (selected.length > 1) {
-          return ($.inArray(dtype, ["image", "dataset"]) > -1);
+      if (selected.length > 0) {
+          return ($.inArray(dtype, ["image", "dataset", "project", "tag", "orphaned"]) > -1);
       } else {
-          return ($.inArray(dtype, ["image", "dataset", "tag", "orphaned", "project"]) > -1);
+          return false;
       }
     }
   });

--- a/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
+++ b/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
@@ -135,7 +135,7 @@ $(function() {
       }
       var dtype = selected[0]['id'].split('-')[0];
       if (selected.length > 0) {
-          return ($.inArray(dtype, ["image", "dataset", "project", "screen", "plate", "acquisition", "tag", "orphaned"]) > -1);
+          return ($.inArray(dtype, ["image", "dataset", "project", "screen", "plate", "acquisition", "tag", "orphaned", "experimenter"]) > -1);
       } else {
           return false;
       }

--- a/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
+++ b/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
@@ -31,7 +31,7 @@ $(function() {
         var childNode = datatree.get_node(childId);
 
         // Skip non-supported children of a tag
-        if (selectedNode.type === "tag" && ($.inArray(childNode.type, ["image", "dataset", "project", "screen", "plate"]) < 0)) {
+        if (selectedNode.type === "tag" && ($.inArray(childNode.type, ["image", "dataset", "project", "screen", "plate", 'acquisition']) < 0)) {
           return;
         }
 
@@ -48,7 +48,7 @@ $(function() {
       });
     });
 
-    var availableTypes = ['Screen', 'Plate', 'Project', 'Dataset', 'Image'];
+    var availableTypes = ['Screen', 'Plate', 'Acquisition', 'Project', 'Dataset', 'Image'];
     // Filter availableTypes to only include types that exist in childrenObjects or selectedObjects
     var objectTypes = new Set([selectedObjects[0].type]);
     childrenObjects.forEach(function(obj) { objectTypes.add(obj.type); });
@@ -56,6 +56,11 @@ $(function() {
     availableTypes = availableTypes.filter(function(type) {
       return objectTypes.has(type.toLowerCase());
     });
+
+    const index = availableTypes.indexOf('Acquisition');
+    if (index !== -1) {
+      availableTypes[index] = 'Run';
+    }  // Rename 'Acquisition' to 'Run' for display
 
     if (availableTypes.length === 0) {
       return;
@@ -90,8 +95,6 @@ $(function() {
       if (tree_selected === undefined || tree_selected.length === 0) {
         return;
       }
-
-      console.log("AutoTag selected:", tree_selected);
 
       // Ensure all selected nodes are loaded
       var nodesToLoad = [];
@@ -132,7 +135,7 @@ $(function() {
       }
       var dtype = selected[0]['id'].split('-')[0];
       if (selected.length > 0) {
-          return ($.inArray(dtype, ["image", "dataset", "project", "screen", "plate", "tag", "orphaned"]) > -1);
+          return ($.inArray(dtype, ["image", "dataset", "project", "screen", "plate", "acquisition", "tag", "orphaned"]) > -1);
       } else {
           return false;
       }

--- a/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
+++ b/omero_autotag/templates/omero_autotag/auto_tag_init.js.html
@@ -1,5 +1,5 @@
 <!-- Update version below to match package.json version for cache busting -->
-<script src="{% static "omero_autotag/js/bundle.min.js" %}?v=4.2.3"></script>
+<script src="{% static "omero_autotag/js/bundle.min.js" %}?v=4.3.0"></script>
 
 <script>
 

--- a/omero_autotag/utils.py
+++ b/omero_autotag/utils.py
@@ -14,6 +14,9 @@ def create_tag_annotations_links(conn, itemType, additions=[], removals=[]):
     model_d = {
         "Image": (omero.model.ImageI, omero.model.ImageAnnotationLinkI),
         "Dataset": (omero.model.DatasetI, omero.model.DatasetAnnotationLinkI),
+        "Project": (omero.model.ProjectI, omero.model.ProjectAnnotationLinkI),
+        "Plate": (omero.model.PlateI, omero.model.PlateAnnotationLinkI),
+        "Screen": (omero.model.ScreenI, omero.model.ScreenAnnotationLinkI),
     }
 
     new_links = []

--- a/omero_autotag/utils.py
+++ b/omero_autotag/utils.py
@@ -17,7 +17,10 @@ def create_tag_annotations_links(conn, itemType, additions=[], removals=[]):
         "Project": (omero.model.ProjectI, omero.model.ProjectAnnotationLinkI),
         "Plate": (omero.model.PlateI, omero.model.PlateAnnotationLinkI),
         "Screen": (omero.model.ScreenI, omero.model.ScreenAnnotationLinkI),
-        "PlateAcquisition": (omero.model.PlateAcquisitionI, omero.model.PlateAcquisitionAnnotationLinkI),
+        "PlateAcquisition": (
+            omero.model.PlateAcquisitionI,
+            omero.model.PlateAcquisitionAnnotationLinkI
+        ),
     }
 
     new_links = []

--- a/omero_autotag/utils.py
+++ b/omero_autotag/utils.py
@@ -17,6 +17,7 @@ def create_tag_annotations_links(conn, itemType, additions=[], removals=[]):
         "Project": (omero.model.ProjectI, omero.model.ProjectAnnotationLinkI),
         "Plate": (omero.model.PlateI, omero.model.PlateAnnotationLinkI),
         "Screen": (omero.model.ScreenI, omero.model.ScreenAnnotationLinkI),
+        "PlateAcquisition": (omero.model.PlateAcquisitionI, omero.model.PlateAcquisitionAnnotationLinkI),
     }
 
     new_links = []

--- a/omero_autotag/views.py
+++ b/omero_autotag/views.py
@@ -30,6 +30,9 @@ def process_update(request, conn=None, **kwargs):
     items = json.loads(request.POST.get("change"))
     itemType = request.POST.get("itemType").capitalize()
 
+    if itemType == "Run":
+        itemType = "PlateAcquisition"
+
     additions = []
     removals = []
 
@@ -117,6 +120,9 @@ def get_items(request, conn=None, **kwargs):
         return HttpResponseNotAllowed("Methods allowed: POST")
 
     itemType = request.POST.get("itemType", "image").capitalize()
+    if itemType == "Run":
+        # PlateAcquisition is displayed as 'Run' in the UI
+        itemType = "PlateAcquisition"
 
     try:
         item_ids = json.loads(request.POST.get("ids") or b"[]")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtagging-autotag",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "",
   "main": "bundle.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtagging-autotag",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "description": "",
   "main": "bundle.js",
   "scripts": {

--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -76,7 +76,12 @@ export default class AutoTagForm extends React.Component {
 
     itemType = itemType.toLowerCase();
 
-    if ($.inArray(itemType, ["image", "dataset", "project", "screen", "plate"]) > -1) {
+    // PlateAcquisition is displayed as 'Run' in the UI
+    if (itemType === 'run') {
+      itemType = 'acquisition';
+    }
+
+    if ($.inArray(itemType, ["image", "dataset", "project", "screen", "plate", 'acquisition']) > -1) {
       const itemIds = [];
       childrenObjects.forEach(obj => {
         if (obj.type === itemType) {
@@ -88,6 +93,7 @@ export default class AutoTagForm extends React.Component {
           itemIds.push(obj.id);
         }
       });
+
       return itemIds;
     }
     return [];

--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -103,8 +103,13 @@ export default class AutoTagForm extends React.Component {
       });
       return datasetIds;
     } else if (itemType === 'Project') {
-      // For projects, use selected projects
+      // For projects, use both children that are projects and selected projects
       const projectIds = [];
+      childrenObjects.forEach(obj => {
+        if (obj.type === 'project') {
+          projectIds.push(obj.id);
+        }
+      });
       selectedObjects.forEach(obj => {
         if (obj.type === 'project') {
           projectIds.push(obj.id);

--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -790,7 +790,6 @@ export default class AutoTagForm extends React.Component {
 
         <AutoTagTable tokenMap={this.filteredTokenMap()}
                       items={this.state.items}
-                      itemType={this.state.selectedItemType}
                       unmappedTags={this.state.unmappedTags}
                       showUnmapped={this.state.showUnmapped}
                       requiredTokenCardinality={this.state.requiredTokenCardinality}

--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -74,50 +74,22 @@ export default class AutoTagForm extends React.Component {
     const childrenObjects = this.props.childrenObjects || [];
     const selectedObjects = this.props.selectedObjects || [];
 
-    if (itemType === 'Image') {
-      // For images, use both children that are images and selected images
-      const imageIds = [];
-      childrenObjects.forEach(obj => {
-        if (obj.type === 'image') {
-          imageIds.push(obj.id);
-        }
-      });
-      selectedObjects.forEach(obj => {
-        if (obj.type === 'image') {
-          imageIds.push(obj.id);
-        }
-      });
-      return imageIds;
-    } else if (itemType === 'Dataset') {
-      // For datasets, use both children that are datasets and selected datasets
-      const datasetIds = [];
-      childrenObjects.forEach(obj => {
-        if (obj.type === 'dataset') {
-          datasetIds.push(obj.id);
-        }
-      });
-      selectedObjects.forEach(obj => {
-        if (obj.type === 'dataset') {
-          datasetIds.push(obj.id);
-        }
-      });
-      return datasetIds;
-    } else if (itemType === 'Project') {
-      // For projects, use both children that are projects and selected projects
-      const projectIds = [];
-      childrenObjects.forEach(obj => {
-        if (obj.type === 'project') {
-          projectIds.push(obj.id);
-        }
-      });
-      selectedObjects.forEach(obj => {
-        if (obj.type === 'project') {
-          projectIds.push(obj.id);
-        }
-      });
-      return projectIds;
-    }
+    itemType = itemType.toLowerCase();
 
+    if ($.inArray(itemType, ["image", "dataset", "project", "screen", "plate"]) > -1) {
+      const itemIds = [];
+      childrenObjects.forEach(obj => {
+        if (obj.type === itemType) {
+          itemIds.push(obj.id);
+        }
+      });
+      selectedObjects.forEach(obj => {
+        if (obj.type === itemType) {
+          itemIds.push(obj.id);
+        }
+      });
+      return itemIds;
+    }
     return [];
   }
 

--- a/src/AutoTagForm.jsx
+++ b/src/AutoTagForm.jsx
@@ -520,7 +520,7 @@ export default class AutoTagForm extends React.Component {
       type: "POST",
       data: {
         change: JSON.stringify(changes),
-        itemType: this.props.itemType
+        itemType: this.state.selectedItemType
       },
       success: function(data) {
         // No action required

--- a/src/AutoTagHeaderRow.jsx
+++ b/src/AutoTagHeaderRow.jsx
@@ -45,7 +45,7 @@ export default class AutoTagHeaderRow extends React.Component {
           {cellNodesTag}
           <th style={{ cursor: 'pointer', userSelect: 'none' }}
               onClick={() => this.props.onSort('name')}>
-            {this.props.itemType==="image"?<div><span>Original Import Path</span><br/><span>Item Name</span></div>:"Item Name"}
+            {this.props.hasFileset?<div><span>Original Import Path</span><br/><span>Item Name</span></div>:"Item Name"}
             {sortArrow}
           </th>
         </tr>

--- a/src/AutoTagHeaderRowTokenCell.jsx
+++ b/src/AutoTagHeaderRowTokenCell.jsx
@@ -93,7 +93,7 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
                  disabled={this.isDisabled()}
                  onChange={this.handleCheckedChangeAll} />
         </div>
-        <div className={'tag'} >
+        <div className={'tag'} data-tooltip-id={this.getTooltipId()}>
           <Select
             name="tokenmapselect"
             onChange={this.selectMapping}
@@ -113,7 +113,6 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
             styles={{
               option: (provided, state) => ({
                 ...provided,
-                // Check if this is the "New / Existing Tag" option
                 color: state.data.value.id === '__new__' ? 'blue' : provided.color,
                 fontWeight: state.data.value.id === '__new__' ? 'bold' : provided.fontWeight,
                 borderStyle: state.data.value.id === '__new__' ? 'solid' : provided.borderStyle,
@@ -122,7 +121,12 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
           />
           {
             this.props.tag &&
-            <ReactTooltip id={this.getTooltipId()} place="top" variant="dark" className={"autotag_tooltip"}>
+            <ReactTooltip
+              id={this.getTooltipId()}
+              place="top"
+              variant="dark"
+              className={"autotag_tooltip"}
+            >
               <ul>
                 <li><strong>ID:</strong> {this.props.tag.id}</li>
                 <li><strong>Value:</strong> {this.props.tag.value}</li>

--- a/src/AutoTagHeaderRowTokenCell.jsx
+++ b/src/AutoTagHeaderRowTokenCell.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Tooltip as ReactTooltip } from 'react-tooltip';
-// lightweight custom dropdown used instead of react-select
+import Select from 'react-select';
 
 export default class AutoTagHeaderRowTokenCell extends React.Component {
 
@@ -12,9 +12,6 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
     this.selectMapping = this.selectMapping.bind(this);
     this.formatTagLabel = this.formatTagLabel.bind(this);
     this.selectGetOptionLabel = this.selectGetOptionLabel.bind(this);
-    this.toggleMenu = this.toggleMenu.bind(this);
-    this.handleDocumentClick = this.handleDocumentClick.bind(this);
-    this.handleOptionSelect = this.handleOptionSelect.bind(this);
 
     this.state = {
       menuOpen: false
@@ -56,46 +53,13 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
     }
   }
 
-  componentDidMount() {
-    document.addEventListener('click', this.handleDocumentClick);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('click', this.handleDocumentClick);
-  }
-
-  toggleMenu(e) {
-    e.stopPropagation();
-    this.setState({menuOpen: !this.state.menuOpen});
-  }
-
-  handleDocumentClick() {
-    if (this.state.menuOpen) {
-      this.setState({menuOpen: false});
-    }
-  }
-
-  handleOptionSelect(tag) {
-    // tag === undefined means New/Existing
-    if (tag === undefined) {
-      this.props.newMapping(this.props.token);
-    } else {
-      this.props.selectMapping(this.props.token, tag);
-    }
-    this.setState({menuOpen: false});
-  }
-
   getTooltipId() {
     return 'tooltip-token-' + this.props.token.value;
   }
 
   selectGetOptionLabel(option) {
-    let label = this.formatTagLabel(option);
-
-    return (
-      <span data-tooltip-id={this.getTooltipId()}>{label}</span>
-    )
-	}
+    return this.formatTagLabel(option.value);
+  }
 
   render() {
     let token = this.props.token;
@@ -118,7 +82,7 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
 
     options.push({
       value: undefined,
-      label: newExisting
+      label: "New/Existing Tag"
     });
 
     let tagClassName = "tag_button";
@@ -135,30 +99,19 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
                  onChange={this.handleCheckedChangeAll} />
         </div>
         <div className={'tag'} >
-          <div className={'tag_dropdown'} style={{position: 'relative', display: 'inline-block'}}>
-            <span className={tagClassName} onClick={this.toggleMenu} data-tooltip-id={tag ? this.getTooltipId() : undefined}>
-              { tag ? ("" + tag.value + "\u00a0(" + tag.id + ")") : '\u00a0' }
-              <span style={{marginLeft:3}}>▾</span>
-            </span>
-            { this.state.menuOpen &&
-              <div className={'tag_dropdown_menu'} style={{position:'absolute', top:'100%', left:0, zIndex:1000, background:'#fff', border:'1px solid #ccc', padding:'4px'}}>
-                {
-                  options.map((opt, idx) => {
-                    const optVal = opt.value; // possibleTag or undefined
-                    const label = (optVal !== undefined) ? (optVal.value + "\u00a0(" + optVal.id + ")") : null;
-                    return (
-                      <div key={idx}
-                           onClick={(e)=>{ e.stopPropagation(); this.handleOptionSelect(optVal); }}
-                           style={{padding:'4px 8px', cursor:'pointer', whiteSpace:'nowrap'}}
-                           data-tooltip-id={optVal ? this.getTooltipId() : undefined}>
-                        { optVal ? label : opt.label }
-                      </div>
-                    );
-                  })
-                }
-              </div>
-            }
-          </div>
+          <Select
+            name="tokenmapselect"
+            onChange={this.selectMapping}
+            options={options}
+            value={options.find(o => o.value?.id === tag?.id)}
+            getOptionLabel={(option) => this.formatTagLabel(option.value)}
+            getOptionValue={(option) => String(option.value?.id)}
+            isSearchable={false}
+            isClearable={true}
+            className={tagClassName}
+            placeholder=" "
+            classNamePrefix="react-select"
+          />
           {
             this.props.tag &&
             <ReactTooltip id={this.getTooltipId()} place="top" variant="dark" className={"autotag_tooltip"}>

--- a/src/AutoTagHeaderRowTokenCell.jsx
+++ b/src/AutoTagHeaderRowTokenCell.jsx
@@ -11,7 +11,6 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
     this.handleCheckedChangeAll = this.handleCheckedChangeAll.bind(this);
     this.selectMapping = this.selectMapping.bind(this);
     this.formatTagLabel = this.formatTagLabel.bind(this);
-    this.selectGetOptionLabel = this.selectGetOptionLabel.bind(this);
 
     this.state = {
       menuOpen: false
@@ -44,21 +43,21 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
   }
 
   selectMapping(option) {
-    if (option === null) {
-      this.props.selectMapping(this.props.token, null);
-    } else if (option.value !== undefined) {
-      this.props.selectMapping(this.props.token, option.value);
-    } else {
-      this.props.newMapping(this.props.token)
-    }
+  if (!option) {
+    this.props.selectMapping(this.props.token, null);
+    return;
   }
+
+  if (option.value.id === '__new__') {
+    this.props.newMapping(this.props.token);
+    return;
+  }
+
+  this.props.selectMapping(this.props.token, option.value);
+}
 
   getTooltipId() {
     return 'tooltip-token-' + this.props.token.value;
-  }
-
-  selectGetOptionLabel(option) {
-    return this.formatTagLabel(option.value);
   }
 
   render() {
@@ -76,12 +75,8 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
       }
     )
 
-    let newExisting = (
-      <span style={{color: "blue", fontWeight: "bold", borderStyle: "solid"}}>New/Existing Tag</span>
-    );
-
     options.push({
-      value: undefined,
+      value: { id: '__new__' },
       label: "New/Existing Tag"
     });
 
@@ -104,13 +99,26 @@ export default class AutoTagHeaderRowTokenCell extends React.Component {
             onChange={this.selectMapping}
             options={options}
             value={options.find(o => o.value?.id === tag?.id)}
-            getOptionLabel={(option) => this.formatTagLabel(option.value)}
-            getOptionValue={(option) => String(option.value?.id)}
+            getOptionLabel={(option) =>
+              option.value.id === '__new__'
+                ? 'New / Existing Tag'
+                : this.formatTagLabel(option.value)
+            }
+            getOptionValue={(option) => option.value.id}
             isSearchable={false}
             isClearable={true}
             className={tagClassName}
             placeholder=" "
             classNamePrefix="react-select"
+            styles={{
+              option: (provided, state) => ({
+                ...provided,
+                // Check if this is the "New / Existing Tag" option
+                color: state.data.value.id === '__new__' ? 'blue' : provided.color,
+                fontWeight: state.data.value.id === '__new__' ? 'bold' : provided.fontWeight,
+                borderStyle: state.data.value.id === '__new__' ? 'solid' : provided.borderStyle,
+              })
+            }}
           />
           {
             this.props.tag &&

--- a/src/AutoTagTable.jsx
+++ b/src/AutoTagTable.jsx
@@ -86,6 +86,8 @@ export default class AutoTagForm extends React.Component {
                          showUnmapped={this.props.showUnmapped} />
     );
 
+    let hasFileset = [...this.props.items].some(item => item.clientPath !== "");
+
     return (
       <div style={{position:'absolute',
                    bottom:'25px',
@@ -102,7 +104,7 @@ export default class AutoTagForm extends React.Component {
                               selectMapping={this.props.selectMapping}
                               newMapping={this.props.newMapping}
                               items={this.props.items}
-                              itemType={this.props.itemType}
+                              hasFileset={hasFileset}
                               handleCheckedChangeAll={this.props.handleCheckedChangeAll}
                               showUnmapped={this.props.showUnmapped}
                               sortColumn={this.state.sortColumn}

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -54,36 +54,32 @@ export default class AutoTagToolbar extends React.Component {
 
         {
           this.props.showUnmapped &&
-          <span
-            data-tooltip-id={'tooltip-toolbar-slider'}
-            style={{
-              float: 'left',
-              marginLeft: '20px',
-              fontSize: '12px',
-              fontWeight: 'bold',
-              lineHeight: '29px'
-            }}
-          >Rarity Threshold&nbsp;&nbsp;{this.props.requiredTokenCardinality}</span>
+          <div style={{display: 'flex', alignItems: 'center', float: 'left', marginLeft: '20px', marginRight: '20px', lineHeight: '29px'}}>
+            <span
+              data-tooltip-id={'tooltip-toolbar-slider'}
+              style={{
+                fontSize: '12px',
+                fontWeight: 'bold',
+                marginRight: '10px'
+              }}
+            >Rarity Threshold&nbsp;&nbsp;{this.props.requiredTokenCardinality}</span>
+            <input className='slider'
+                   type='range'
+                   onChange={this.handleChangeRequiredTokenCardinality}
+                   value={this.props.requiredTokenCardinality}
+                   min={1}
+                   max={this.props.maxTokenCardinality}
+                   style={{
+                     cursor: 'pointer'
+                   }} />
+          </div>
         }
         {
           this.props.showUnmapped &&
-          <input className='slider'
-                 type='range'
-                 onChange={this.handleChangeRequiredTokenCardinality}
-                 value={this.props.requiredTokenCardinality}
-                 min={1}
-                 max={this.props.maxTokenCardinality}
-                 style={{
-                   float: 'left',
-                   marginLeft: '10px',
-                   lineHeight: '29px',
-                   paddingTop: '5px'
-                 }} />
+          <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" variant="dark">
+            Hide columns if token is found on fewer than this number of items.
+          </ReactTooltip>
         }
-
-        <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" variant="dark">
-          Hide columns if token is found on fewer than this number of items.
-        </ReactTooltip>
 
         <span
           data-tooltip-id={'tooltip-toolbar-split-chars'}

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -48,11 +48,34 @@ export default class AutoTagToolbar extends React.Component {
           data-tooltip-id={'tooltip-toolbar-obj-type'}
           style={{float: 'left', marginLeft: '10px', fontSize: '12px', fontWeight: 'bold', lineHeight: '29px'}}
         >
-          Tagging {this.props.itemType}s
+          {this.props.availableTypes && this.props.availableTypes.length > 1 ? (
+            <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+              <label htmlFor="itemTypeSelect" style={{margin: '0'}}>
+                Tagging
+              </label>
+              <select
+                id="itemTypeSelect"
+                value={this.props.selectedItemType || ''}
+                onChange={this.props.handleChangeItemType}
+                style={{padding: '4px', fontSize: '12px', cursor: 'pointer'}}
+              >
+                {this.props.availableTypes.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : (
+            `Tagging ${this.props.itemType}s`
+          )}
         </span>
 
         <ReactTooltip id={'tooltip-toolbar-obj-type'} place="bottom" variant="dark" offset={5}>
-          The object type currently being tagged. Selecting a Project will tag Datasets, selecting a Dataset or an Image will tag Images.
+          {this.props.availableTypes && this.props.availableTypes.length > 1
+            ? 'Select which object type to tag'
+            : 'The object type currently being tagged. Selecting a Project will tag Datasets, selecting a Dataset or an Image will tag Images.'
+          }
         </ReactTooltip>
 
         {

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -45,12 +45,15 @@ export default class AutoTagToolbar extends React.Component {
         className={'toolbar'}
       >
         <span
-          data-tip
-          data-for={'tooltip-toolbar-show-all'}
+          data-tooltip-id={'tooltip-toolbar-obj-type'}
           style={{float: 'left', marginLeft: '10px', fontSize: '12px', fontWeight: 'bold', lineHeight: '29px'}}
         >
           Tagging {this.props.itemType}s
         </span>
+
+        <ReactTooltip id={'tooltip-toolbar-obj-type'} place="bottom" variant="dark" offset={5}>
+          The object type currently being tagged. Selecting a Project will tag Datasets, selecting a Dataset or an Image will tag Images.
+        </ReactTooltip>
 
         {
           this.props.showUnmapped &&
@@ -72,13 +75,13 @@ export default class AutoTagToolbar extends React.Component {
                    style={{
                      cursor: 'pointer'
                    }} />
+            {
+              this.props.showUnmapped &&
+              <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" variant="dark" offset={-4} style={{lineHeight: '1'}}>
+                Hide columns if token is found on fewer than this number of items.
+              </ReactTooltip>
+            }
           </div>
-        }
-        {
-          this.props.showUnmapped &&
-          <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" variant="dark">
-            Hide columns if token is found on fewer than this number of items.
-          </ReactTooltip>
         }
 
         <span
@@ -88,7 +91,7 @@ export default class AutoTagToolbar extends React.Component {
           Split on&nbsp;
         </span>
 
-        <ReactTooltip id={'tooltip-toolbar-split-chars'} place="bottom" variant="dark">
+        <ReactTooltip id={'tooltip-toolbar-split-chars'} place="bottom" variant="dark" offset={5}>
           Characters used to split the path and names to find relevant tags.
         </ReactTooltip>
 
@@ -107,7 +110,7 @@ export default class AutoTagToolbar extends React.Component {
           Show All Potential Tags
         </span>
 
-        <ReactTooltip id={'tooltip-toolbar-show-all'} place="bottom" variant="dark">
+        <ReactTooltip id={'tooltip-toolbar-show-all'} place="bottom" variant="dark" offset={5}>
           Show all the tokens found in the filenames that do not match an existing tag
         </ReactTooltip>
 

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -106,7 +106,7 @@ export default class AutoTagToolbar extends React.Component {
 
         <span
           data-tooltip-id={'tooltip-toolbar-show-all'}
-          style={{fontSize: '12px', fontWeight: 'bold', lineHeight: '29px'}}
+          style={{fontSize: '12px', fontWeight: 'bold', lineHeight: '29px', marginRight: '5px'}}
         >
           Show All Potential Tags
         </span>
@@ -119,7 +119,9 @@ export default class AutoTagToolbar extends React.Component {
                checked={this.props.showUnmapped}
                onChange={this.toggleUnmapped}
                style={{
-                marginRight: '20px'
+                verticalAlign: 'middle',
+                marginRight: '20px',
+                cursor: 'pointer'
               }} />
 
         <input type="submit"

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -57,7 +57,7 @@ export default class AutoTagToolbar extends React.Component {
             variant="dark"
             offset={5}
             className={'autotag_toolbar_tooltip'} >
-          The object type currently being tagged. Selecting a Project will tag Datasets, selecting a Dataset or an Image will tag Images.
+          The object type currently being tagged.
         </ReactTooltip>
 
         {

--- a/src/AutoTagToolbar.jsx
+++ b/src/AutoTagToolbar.jsx
@@ -51,7 +51,12 @@ export default class AutoTagToolbar extends React.Component {
           Tagging {this.props.itemType}s
         </span>
 
-        <ReactTooltip id={'tooltip-toolbar-obj-type'} place="bottom" variant="dark" offset={5}>
+        <ReactTooltip
+            id={'tooltip-toolbar-obj-type'}
+            place="bottom"
+            variant="dark"
+            offset={5}
+            className={'autotag_toolbar_tooltip'} >
           The object type currently being tagged. Selecting a Project will tag Datasets, selecting a Dataset or an Image will tag Images.
         </ReactTooltip>
 
@@ -77,7 +82,12 @@ export default class AutoTagToolbar extends React.Component {
                    }} />
             {
               this.props.showUnmapped &&
-              <ReactTooltip id={'tooltip-toolbar-slider'} place="bottom" variant="dark" offset={-4} style={{lineHeight: '1'}}>
+              <ReactTooltip
+                  id={'tooltip-toolbar-slider'}
+                  place="bottom"
+                  variant="dark"
+                  offset={-4}
+                  className={'autotag_toolbar_tooltip'} >
                 Hide columns if token is found on fewer than this number of items.
               </ReactTooltip>
             }
@@ -91,7 +101,12 @@ export default class AutoTagToolbar extends React.Component {
           Split on&nbsp;
         </span>
 
-        <ReactTooltip id={'tooltip-toolbar-split-chars'} place="bottom" variant="dark" offset={5}>
+        <ReactTooltip
+            id={'tooltip-toolbar-split-chars'}
+            place="bottom"
+            variant="dark"
+            offset={5}
+            className={'autotag_toolbar_tooltip'} >
           Characters used to split the path and names to find relevant tags.
         </ReactTooltip>
 
@@ -110,7 +125,12 @@ export default class AutoTagToolbar extends React.Component {
           Show All Potential Tags
         </span>
 
-        <ReactTooltip id={'tooltip-toolbar-show-all'} place="bottom" variant="dark" offset={5}>
+        <ReactTooltip
+            id={'tooltip-toolbar-show-all'}
+            place="bottom"
+            variant="dark"
+            offset={5}
+            className={'autotag_toolbar_tooltip'} >
           Show all the tokens found in the filenames that do not match an existing tag
         </ReactTooltip>
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,15 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import AutoTagForm from './AutoTagForm';
 
-function autotagform(itemIds, itemType, url, urlUpdate, urlCreateTag) {
+function autotagform(selectedObjects, childrenObjects, availableTypes, defaultType, url, urlUpdate, urlCreateTag) {
   ReactDOM.render(
     <AutoTagForm url={url}
                  urlUpdate={urlUpdate}
                  urlCreateTag={urlCreateTag}
-                 itemIds={itemIds}
-                 itemType={itemType} />,
-    document.getElementById('auto_tag_panel')
+                 selectedObjects={selectedObjects}
+                 childrenObjects={childrenObjects}
+                 availableTypes={availableTypes}
+                 defaultType={defaultType} />,
+  document.getElementById('auto_tag_panel')
   );
 }
-
 export default autotagform;

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -292,7 +292,7 @@
 
 #auto_tag_panel .react-select__placeholder,
 #auto_tag_panel .react-select__single-value {
-  padding-left: 7px;
+  padding-left: 5px;
   padding-right: 5px;
   white-space: nowrap;
   position: inherit;
@@ -389,13 +389,20 @@
   vertical-align: middle;
   white-space: nowrap;
   padding-right: 0px;
-  padding-left: 0px;
   padding-bottom: 0px;
+}
+
+#auto_tag_panel .react-select__clear-indicator,
+#auto_tag_panel .react-select__dropdown-indicator,
+#auto_tag_panel .react-select__indicators {
+  padding-left: 0px;
 }
 
 #auto_tag_panel .react-select__dropdown-indicator svg {
   width: 10px;
   height: 10px;
+  color: hsl(205, 30%, 35%);
+  fill: currentColor;
 }
 
 #auto_tag_panel .react-select__clear-indicator svg {

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -430,7 +430,7 @@
 	background:linear-gradient(to top, hsl(205,65%,80%) 0%,hsl(205,70%,75%) 100%); /* W3C */
 
 	text-decoration:none;
-	text-shadow: 0 1px 0 rgba(255,255,255,.4);
+	/*text-shadow: 0 1px 0 rgba(255,255,255,.4);*/
 	color:hsl(205,30%,30%);
 }
 

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -512,10 +512,16 @@
 
 #auto_tag_panel .autotag_tooltip {
     text-align: left;
-    font-size: 11px;
+    font-size: 12px;
     padding-top: 8px;
     padding-bottom: 8px;
     padding-left: 6px;
     padding-right: 30px;
     z-index: 1000;
+}
+
+#auto_tag_panel .autotag_toolbar_tooltip {
+    font-size: 13px;
+    z-index: 1000;
+    line-height: 1;
 }

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -365,6 +365,14 @@
 #auto_tag_panel .react-select__control {
   display: inline !important;
   white-space: nowrap !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+#auto_tag_panel .react-select__control:focus,
+#auto_tag_panel .react-select__control:focus-within {
+  outline: none !important;
+  box-shadow: none !important;
 }
 
 #auto_tag_panel .react-select__value-container {

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -517,4 +517,5 @@
     padding-bottom: 8px;
     padding-left: 6px;
     padding-right: 30px;
+    z-index: 1000;
 }

--- a/src/webtagging.css
+++ b/src/webtagging.css
@@ -1,15 +1,16 @@
 
 /* Correct some aggressive CSS rules from dusty.css */
-.Select-arrow-zone {
-    display:table-cell !important;
+#auto_tag_panel .react-select__dropdown-indicator {
+  display: table-cell !important;
 }
 
-.Select-clear-zone {
-    display:table-cell !important;
+#auto_tag_panel .react-select__clear-indicator {
+  display: table-cell !important;
 }
 
-.Select-placeholder, .Select-option {
-    font-size:14px;
+#auto_tag_panel .react-select__placeholder,
+#auto_tag_panel .react-select__option {
+  font-size: 14px;
 }
 
 #auto_tag_panel .toolbar {
@@ -73,6 +74,8 @@
 
 #auto_tag_panel .token {
     text-align:center;
+    display: inline-flex;
+    align-items: center;
 }
 
 #auto_tag_panel .tag {
@@ -287,93 +290,113 @@
   }
 }
 
-#auto_tag_panel .Select-placeholder,
-#auto_tag_panel .Select-value {
+#auto_tag_panel .react-select__placeholder,
+#auto_tag_panel .react-select__single-value {
   padding-left: 7px;
   padding-right: 5px;
   white-space: nowrap;
-  position:inherit;
+  position: inherit;
   display: table-cell;
 }
 
-#auto_tag_panel .Select-control {
-    line-height:inherit;
-    height: auto;
-    border: 1px solid transparent;
+#auto_tag_panel .react-select__control {
+  line-height: inherit;
+  height: auto;
+  border: 1px solid transparent;
+  background: none transparent;
 }
 
-#auto_tag_panel .Select-placeholder,
-#auto_tag_panel .Select-value,
-#auto_tag_panel .Select-clear-zone,
-#auto_tag_panel .Select-arrow-zone {
+#auto_tag_panel .react-select__placeholder,
+#auto_tag_panel .react-select__single-value,
+#auto_tag_panel .react-select__clear-indicator,
+#auto_tag_panel .react-select__dropdown-indicator {
   line-height: inherit;
   height: auto;
   cursor: pointer;
 }
 
-#auto_tag_panel .Select-value-label {
-    text-shadow: 0 1px 0 rgba(255,255,255,.8);
-    color:hsl(205,30%,35%);
+#auto_tag_panel .react-select__single-value {
+  text-shadow: 0 1px 0 rgba(255,255,255,.8);
+  color: hsl(205,30%,35%);
 }
 
-#auto_tag_panel .Select-input {
-    line-height: inherit;
-    height: auto;
-    padding-left: 0;
-    padding-right: 0;
+#auto_tag_panel .react-select__input-container {
+  line-height: inherit;
+  height: auto;
+  padding-left: 0;
+  padding-right: 0;
 }
 
-#auto_tag_panel .Select-clear-zone,
-#auto_tag_panel .Select-arrow-zone {
-    padding: 0px 2px 0px 2px;
+#auto_tag_panel .react-select__clear-indicator,
+#auto_tag_panel .react-select__dropdown-indicator {
+  padding: 0px 2px;
 }
 
-#auto_tag_panel .Select-arrow-zone {
-    padding-top: 2px;
-    padding-right: 7px;
+#auto_tag_panel .react-select__dropdown-indicator {
+  padding-top: 2px;
+  padding-right: 7px;
 }
 
-#auto_tag_panel .Select-clear-zone{
-    font-weight: bold;
-    padding-bottom: 2px;
-    padding-right: 4px;
+#auto_tag_panel .react-select__clear-indicator {
+  font-weight: bold;
+  padding-bottom: 2px;
+  padding-right: 4px;
+  font-size: 10px;
+  color: black;
 }
 
-#auto_tag_panel .Select-control {
-  background: none transparent;
+#auto_tag_panel .react-select__placeholder {
+  font-size: inherit;
+  color: inherit;
 }
 
-#auto_tag_panel .Select-placeholder {
-    font-size: inherit;
-    color: inherit;
+#auto_tag_panel .react-select__menu {
+  width: auto;
+  margin-top: 2px;
 }
 
-#auto_tag_panel .Select-clear {
-    font-size: 10px;
-    color: black;
+#auto_tag_panel .react-select__option {
+  width: auto;
+  font-size: 11px;
+  padding-top: 3px;
+  padding-bottom: 3px;
 }
 
-#auto_tag_panel .Select-menu-outer {
-    width: auto;
-    margin-top: 2px;
+#auto_tag_panel .react-select__control {
+  display: inline !important;
+  white-space: nowrap !important;
 }
 
-#auto_tag_panel .Select-option {
-    width: auto;
-    font-size: 11px;
-    padding-top: 3px;
-    padding-bottom: 3px;
+#auto_tag_panel .react-select__value-container {
+  display: table-row !important;
+  padding-right: 0px;
+  padding-left: 2px;
+}
+
+#auto_tag_panel .react-select__single-value,
+#auto_tag_panel .react-select__clear-indicator,
+#auto_tag_panel .react-select__dropdown-indicator,
+#auto_tag_panel .react-select__indicators {
+  display: inline-flex !important;
+  vertical-align: middle;
+  white-space: nowrap;
+  padding-right: 0px;
+  padding-left: 0px;
+  padding-bottom: 0px;
+}
+
+#auto_tag_panel .react-select__dropdown-indicator svg {
+  width: 10px;
+  height: 10px;
+}
+
+#auto_tag_panel .react-select__clear-indicator svg {
+  width: 10px;
+  height: 10px;
 }
 
 #auto_tag_panel .tag_button {
-	display:inline-flex;
-	align-items:center;
-	justify-content:center;
-	vertical-align:middle;
-	padding-left: 7px;
-  padding-right: 5px;
-  padding-top: 1px;
-  padding-bottom: 1px;
+  display:inline-block;
     -webkit-border-radius: 30px;
 	-moz-border-radius: 30px;
 	border-radius: 30px;


### PR DESCRIPTION
This PR implements multi-selection of objects and introduces a new select field to chose what type is being tagged (otherwise parent child logic is too complex and unintuitive with multi-type support).

Fix #3

Supported type list of possible tagged object has been extended to `Project`, `Plate`, `Screen` and `Run` from the earlier abstraction of object types (see https://github.com/German-BioImaging/omero-autotag/pull/28).

Now a choices of what object to tag is available from a dropdown list. Options are limited to the current selected type and children of that selected object (if not empty) to prevent useless choice from being proposed.
Note the exception of selection of objects from tags that suggest all available children types (if not empty) beside the tags themselves (no tagging of tags from tags with the autotag plugin please).

Selecting multiple datasets to tag them:
<img width="1268" height="353" alt="image" src="https://github.com/user-attachments/assets/3cc0512e-efdc-4e4e-9ef7-5922de5e401c" />

Same dataset selected but chosing to tag images instead:
<img width="1282" height="364" alt="image" src="https://github.com/user-attachments/assets/d0fc209c-0906-49e2-a073-e99ceebc3dc9" />

Autotagging from tags will display only the available choices of object types to tag. If only one choice, no dropdown list:
<img width="1367" height="618" alt="image" src="https://github.com/user-attachments/assets/11193f35-9653-4762-8b73-583cf2f05ae1" />

Selecting images now only offers to tag the selected images:
<img width="1294" height="327" alt="image" src="https://github.com/user-attachments/assets/867ae8c1-ae4d-40db-a89e-9bd3ad099052" />

Fix #39 with a fix of the Image HQL query that includes images with no filesets (later handled in JS like other data type with empty clientPath).