### PR TITLE
plugin version update from github tag in GH action

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
   schedule:
     - cron: '0 0 * * *'  # Runs every day at midnight
+  workflow_dispatch:
+    inputs:
+      fake_version:
+        description: "Version to test"
+        required: false
 
 jobs:
   build-n-publish:
@@ -14,10 +19,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Sync version from tag
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          VERSION=${TAG#v}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.fake_version || '0.0.0-dev' }}"
+          else
+            TAG=${GITHUB_REF#refs/tags/}
+            VERSION=${TAG#v}
+          fi
           echo "Using version $VERSION"
 
           # Update package.json (JS + Python source of truth)

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -12,6 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Sync version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#v}
+          echo "Using version $VERSION"
+
+          # Update package.json (JS + Python source of truth)
+          jq --arg v "$VERSION" '.version = $v' package.json > package.tmp
+          mv package.tmp package.json
+
+          # Update JS cache-busting version
+          sed -i 's/\(?v=\)[0-9.]\+/\1'"$VERSION"'/' omero_autotag/templates/omero_autotag/auto_tag_init.js.html
+      
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'


### PR DESCRIPTION
Release of the plugin is made by pushing a tag (e.g v4.5.6). The tag is picked up by the workflow and release the plugin on pypi and creates a github release. But the version also needs to be updated in two other file, package.json and in the html entry point of the plugin. The later uses the version to bust the cache of previous version when an update is made. 

This change reads the tag version in the publish_pypi.yml workflow and updates the version in the two files before the auto release.